### PR TITLE
[#16] 이메일 인증 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,17 +54,15 @@ jacocoTestReport {
         classDirectories.setFrom(
                 files(classDirectories.files.collect {
                     fileTree(dir: it, excludes: [
-                            "**.domain.**",
                             "**.*Application*",
-                            "**.*Config*",
-                            "**.*Dto*",
-                            "**.*Request*",
-                            "**.*Response*",
-                            "**.*Exception*",
-                            "**.*Mapper*",
-                            "**/equals",
-                            "**/hashCode",
-                            "**/toString"
+                            "**/config/*Config*",
+                            "**/dto/*Dto*",
+                            "**/request/*Request*",
+                            "**/response/*Response*",
+                            "**/exception/*Exception*",
+                            "**/mapper/*Mapper*",
+                            "**/*Dao*",
+                            "**/*Generator*"
                     ])
                 })
         )
@@ -95,17 +93,15 @@ jacocoTestCoverageVerification {
             }
 
             excludes = [
-                    "**.domain.**",
                     "**.*Application*",
-                    "**.*Config*",
-                    "**.*Dto*",
-                    "**.*Request*",
-                    "**.*Response*",
-                    "**.*Exception*",
-                    "**.*Mapper*",
-                    "**/equals",
-                    "**/hashCode",
-                    "**/toString"
+                    "**/config/*Config*",
+                    "**/dto/*Dto*",
+                    "**/request/*Request*",
+                    "**/response/*Response*",
+                    "**/exception/*Exception*",
+                    "**/mapper/*Mapper*",
+                    "**/*Dao*",
+                    "**/*Generator*"
             ]
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,9 @@ dependencies {
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
     implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/jinddung2/givemeticon/common/config/RedisConfig.java
+++ b/src/main/java/com/jinddung2/givemeticon/common/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package com.jinddung2.givemeticon.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.mail.host}")
+    private String host;
+    @Value("${spring.data.redis.mail.port}")
+    private int port;
+
+    @Bean(name = "redisMailConnectionFactory")
+    public RedisConnectionFactory redisMailConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean(name = "redisTemplate")
+    public StringRedisTemplate redisTemplate() {
+        StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisMailConnectionFactory());
+        return stringRedisTemplate;
+    }
+}
+

--- a/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
+++ b/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
     // AUTH
     UNAUTHENTICATED("로그인이 필요한 기능입니다."),
     UNAUTHORIZED("해당 권한이 없습니다."),
+    INVALID_CERTIFICATED_NUMBER("인증 번호가 다릅니다."),
 
     // MEMBER
     DUPLICATED_EMAIL("이미 존재하는 이메일입니다."),

--- a/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
+++ b/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
@@ -7,6 +7,7 @@ public enum ErrorCode {
     // AUTH
     UNAUTHENTICATED("로그인이 필요한 기능입니다."),
     UNAUTHORIZED("해당 권한이 없습니다."),
+    NOT_FOUND_EMAIL("이메일이 존재하지 않습니다."),
     INVALID_CERTIFICATED_NUMBER("인증 번호가 다릅니다."),
 
     // MEMBER

--- a/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
@@ -1,7 +1,8 @@
 package com.jinddung2.givemeticon.mail.advice;
 
 import com.jinddung2.givemeticon.common.response.ErrorResult;
-import com.jinddung2.givemeticon.mail.exception.MailException;
+import com.jinddung2.givemeticon.mail.exception.EmailNotFoundException;
+import com.jinddung2.givemeticon.mail.exception.InvalidCertificationNumberException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,10 +13,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 public class MailExceptionAdvice {
 
-    @ExceptionHandler(MailException.class)
-    public ResponseEntity<ErrorResult> handleMailException(MailException e) {
+    @ExceptionHandler(EmailNotFoundException.class)
+    public ResponseEntity<ErrorResult> handleEmailNotFoundException(EmailNotFoundException e) {
         ErrorResult errorResult = new ErrorResult(e.getMessage());
-        log.debug("mail exception!! error msg={}", errorResult);
+        log.error("mail exception!! error msg={}", errorResult);
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(InvalidCertificationNumberException.class)
+    public ResponseEntity<ErrorResult> handleInvalidCertificationNumberException(InvalidCertificationNumberException e) {
+        ErrorResult errorResult = new ErrorResult(e.getMessage());
+        log.error("mail exception!! error msg={}", errorResult);
         return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
@@ -15,7 +15,7 @@ public class MailExceptionAdvice {
     @ExceptionHandler(MailException.class)
     public ResponseEntity<ErrorResult> handleMailException(MailException e) {
         ErrorResult errorResult = new ErrorResult(e.getMessage());
-        log.info("mail exception!! error msg={}", errorResult);
+        log.debug("mail exception!! error msg={}", errorResult);
         return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/advice/MailExceptionAdvice.java
@@ -1,0 +1,21 @@
+package com.jinddung2.givemeticon.mail.advice;
+
+import com.jinddung2.givemeticon.common.response.ErrorResult;
+import com.jinddung2.givemeticon.mail.exception.MailException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class MailExceptionAdvice {
+
+    @ExceptionHandler(MailException.class)
+    public ResponseEntity<ErrorResult> handleMailException(MailException e) {
+        ErrorResult errorResult = new ErrorResult(e.getMessage());
+        log.info("mail exception!! error msg={}", errorResult);
+        return new ResponseEntity<>(errorResult, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailCustomProperties.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailCustomProperties.java
@@ -1,0 +1,18 @@
+package com.jinddung2.givemeticon.mail.application;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@ConfigurationProperties(prefix = "mail")
+@RequiredArgsConstructor
+public class MailCustomProperties {
+    @Value("${mail.title.certification}")
+    private String mailTitleCertification;
+    @Value("${mail.domain.name}")
+    private String domainName;
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
@@ -1,0 +1,42 @@
+package com.jinddung2.givemeticon.mail.application;
+
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationGenerator;
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.security.NoSuchAlgorithmException;
+
+import static com.jinddung2.givemeticon.mail.constans.EmailConstants.DOMAIN_NAME;
+import static com.jinddung2.givemeticon.mail.constans.EmailConstants.MAIL_TITLE_CERTIFICATION;
+
+@Service
+@RequiredArgsConstructor
+public class MailSendService {
+
+    private final JavaMailSender mailSender;
+    private final CertificationNumberDao certificationNumberDao;
+    private final CertificationGenerator generator;
+
+    public void sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
+
+        String certificationNumber = generator.createCertificationNumber();
+
+        String content = String.format("%s/api/v1/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", DOMAIN_NAME, certificationNumber, email);
+        sendMail(email, content);
+        certificationNumberDao.saveCertificationNumber(email, certificationNumber);
+    }
+
+    private void sendMail(String email, String content) throws MessagingException {
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+        helper.setTo(email);
+        helper.setSubject(MAIL_TITLE_CERTIFICATION);
+        helper.setText(content);
+        mailSender.send(mimeMessage);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
@@ -12,9 +12,6 @@ import org.springframework.stereotype.Service;
 
 import java.security.NoSuchAlgorithmException;
 
-import static com.jinddung2.givemeticon.mail.constans.EmailConstants.DOMAIN_NAME;
-import static com.jinddung2.givemeticon.mail.constans.EmailConstants.MAIL_TITLE_CERTIFICATION;
-
 @Service
 @RequiredArgsConstructor
 public class MailSendService {
@@ -22,14 +19,14 @@ public class MailSendService {
     private final JavaMailSender mailSender;
     private final CertificationNumberDao certificationNumberDao;
     private final CertificationGenerator generator;
+    private final MailCustomProperties properties;
 
     public EmailCertificationResponse sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
 
         String certificationNumber = generator.createCertificationNumber();
-
-        String content = String.format("%s/api/v1/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", DOMAIN_NAME, certificationNumber, email);
-        sendMail(email, content);
+        String content = String.format("%s/api/v1/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", properties.getDomainName(), certificationNumber, email);
         certificationNumberDao.saveCertificationNumber(email, certificationNumber);
+        sendMail(email, content);
         return new EmailCertificationResponse(email, certificationNumber);
     }
 
@@ -37,7 +34,7 @@ public class MailSendService {
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
         helper.setTo(email);
-        helper.setSubject(MAIL_TITLE_CERTIFICATION);
+        helper.setSubject(properties.getMailTitleCertification());
         helper.setText(content);
         mailSender.send(mimeMessage);
     }

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailSendService.java
@@ -2,6 +2,7 @@ package com.jinddung2.givemeticon.mail.application;
 
 import com.jinddung2.givemeticon.mail.infrastructure.CertificationGenerator;
 import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
+import com.jinddung2.givemeticon.mail.presentation.response.EmailCertificationResponse;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +23,14 @@ public class MailSendService {
     private final CertificationNumberDao certificationNumberDao;
     private final CertificationGenerator generator;
 
-    public void sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
+    public EmailCertificationResponse sendEmailForCertification(String email) throws NoSuchAlgorithmException, MessagingException {
 
         String certificationNumber = generator.createCertificationNumber();
 
         String content = String.format("%s/api/v1/users/verify?certificationNumber=%s&email=%s   링크를 3분 이내에 클릭해주세요.", DOMAIN_NAME, certificationNumber, email);
         sendMail(email, content);
         certificationNumberDao.saveCertificationNumber(email, certificationNumber);
+        return new EmailCertificationResponse(email, certificationNumber);
     }
 
     private void sendMail(String email, String content) throws MessagingException {

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailVerifyService.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailVerifyService.java
@@ -1,5 +1,6 @@
 package com.jinddung2.givemeticon.mail.application;
 
+import com.jinddung2.givemeticon.mail.exception.EmailNotFoundException;
 import com.jinddung2.givemeticon.mail.exception.InvalidCertificationNumberException;
 import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
 import lombok.RequiredArgsConstructor;
@@ -19,8 +20,15 @@ public class MailVerifyService {
     }
 
     private boolean isVerify(String email, String certificationNumber) {
-        return (certificationNumberDao.hasKey(email) &&
-                certificationNumberDao.getCertificationNumber(email)
-                        .equals(certificationNumber));
+        boolean validatedEmail = isEmailExists(email);
+        if (!isEmailExists(email)) {
+            throw new EmailNotFoundException();
+        }
+        return (validatedEmail &&
+                certificationNumberDao.getCertificationNumber(email).equals(certificationNumber));
+    }
+
+    private boolean isEmailExists(String email) {
+        return certificationNumberDao.hasKey(email);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/mail/application/MailVerifyService.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/application/MailVerifyService.java
@@ -1,0 +1,26 @@
+package com.jinddung2.givemeticon.mail.application;
+
+import com.jinddung2.givemeticon.mail.exception.InvalidCertificationNumberException;
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailVerifyService {
+
+    private final CertificationNumberDao certificationNumberDao;
+
+    public void verifyEmail(String email, String certificationNumber) {
+        if (!isVerify(email, certificationNumber)) {
+            throw new InvalidCertificationNumberException();
+        }
+        certificationNumberDao.removeCertificationNumber(email);
+    }
+
+    private boolean isVerify(String email, String certificationNumber) {
+        return (certificationNumberDao.hasKey(email) &&
+                certificationNumberDao.getCertificationNumber(email)
+                        .equals(certificationNumber));
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/constans/EmailConstants.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/constans/EmailConstants.java
@@ -1,0 +1,7 @@
+package com.jinddung2.givemeticon.mail.constans;
+
+public class EmailConstants {
+    public static final String MAIL_TITLE_CERTIFICATION = "givemeticon 인증번호 안내";
+    public static final String DOMAIN_NAME = "http://localhost:8080";
+    public static final int EMAIL_VERIFICATION_LIMIT_IN_SECONDS = 3 * 60;
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/constans/EmailConstants.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/constans/EmailConstants.java
@@ -1,7 +1,0 @@
-package com.jinddung2.givemeticon.mail.constans;
-
-public class EmailConstants {
-    public static final String MAIL_TITLE_CERTIFICATION = "givemeticon 인증번호 안내";
-    public static final String DOMAIN_NAME = "http://localhost:8080";
-    public static final int EMAIL_VERIFICATION_LIMIT_IN_SECONDS = 3 * 60;
-}

--- a/src/main/java/com/jinddung2/givemeticon/mail/exception/EmailNotFoundException.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/exception/EmailNotFoundException.java
@@ -1,0 +1,9 @@
+package com.jinddung2.givemeticon.mail.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+
+public class EmailNotFoundException extends MailException {
+    public EmailNotFoundException() {
+        super(ErrorCode.NOT_FOUND_EMAIL);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/exception/InvalidCertificationNumberException.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/exception/InvalidCertificationNumberException.java
@@ -1,0 +1,9 @@
+package com.jinddung2.givemeticon.mail.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+
+public class InvalidCertificationNumberException extends MailException {
+    public InvalidCertificationNumberException() {
+        super(ErrorCode.INVALID_CERTIFICATED_NUMBER);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/exception/MailException.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/exception/MailException.java
@@ -1,0 +1,10 @@
+package com.jinddung2.givemeticon.mail.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+import com.jinddung2.givemeticon.common.exception.GiveMeTiConException;
+
+public class MailException extends GiveMeTiConException {
+    public MailException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationGenerator.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationGenerator.java
@@ -1,0 +1,20 @@
+package com.jinddung2.givemeticon.mail.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+@Component
+public class CertificationGenerator {
+    public String createCertificationNumber() throws NoSuchAlgorithmException {
+        String result;
+
+        do {
+            int num = SecureRandom.getInstanceStrong().nextInt(999999);
+            result = String.valueOf(num);
+        } while (result.length() != 6);
+
+        return result;
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
@@ -1,0 +1,27 @@
+package com.jinddung2.givemeticon.mail.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+import static com.jinddung2.givemeticon.mail.constans.EmailConstants.EMAIL_VERIFICATION_LIMIT_IN_SECONDS;
+
+@Repository
+@RequiredArgsConstructor
+public class CertificationNumberDao {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void saveCertificationNumber(String email, String certificationNumber) {
+        redisTemplate.opsForValue()
+                .set(email, certificationNumber,
+                        Duration.ofSeconds(EMAIL_VERIFICATION_LIMIT_IN_SECONDS));
+    }
+
+    public boolean hasKey(String email) {
+        Boolean keyExists = redisTemplate.hasKey(email);
+        return keyExists != null && keyExists;
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
@@ -20,6 +20,14 @@ public class CertificationNumberDao {
                         Duration.ofSeconds(EMAIL_VERIFICATION_LIMIT_IN_SECONDS));
     }
 
+    public String getCertificationNumber(String email) {
+        return redisTemplate.opsForValue().get(email);
+    }
+
+    public void removeCertificationNumber(String email) {
+        redisTemplate.delete(email);
+    }
+
     public boolean hasKey(String email) {
         Boolean keyExists = redisTemplate.hasKey(email);
         return keyExists != null && keyExists;

--- a/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/infrastructure/CertificationNumberDao.java
@@ -6,13 +6,13 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 
-import static com.jinddung2.givemeticon.mail.constans.EmailConstants.EMAIL_VERIFICATION_LIMIT_IN_SECONDS;
 
 @Repository
 @RequiredArgsConstructor
 public class CertificationNumberDao {
 
     private final StringRedisTemplate redisTemplate;
+    public static final int EMAIL_VERIFICATION_LIMIT_IN_SECONDS = 180;
 
     public void saveCertificationNumber(String email, String certificationNumber) {
         redisTemplate.opsForValue()

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
@@ -1,0 +1,30 @@
+package com.jinddung2.givemeticon.mail.presentation;
+
+import com.jinddung2.givemeticon.common.response.ApiResponse;
+import com.jinddung2.givemeticon.mail.application.MailSendService;
+import com.jinddung2.givemeticon.mail.presentation.request.EmailCertificationRequest;
+import jakarta.mail.MessagingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.NoSuchAlgorithmException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class MailController {
+
+    private final MailSendService mailSendService;
+
+    @PostMapping("/send-certification")
+    public ResponseEntity<ApiResponse<Void>> sendCertificationNumber(@Validated @RequestBody EmailCertificationRequest request)
+            throws MessagingException, NoSuchAlgorithmException {
+        mailSendService.sendEmailForCertification(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
@@ -2,29 +2,37 @@ package com.jinddung2.givemeticon.mail.presentation;
 
 import com.jinddung2.givemeticon.common.response.ApiResponse;
 import com.jinddung2.givemeticon.mail.application.MailSendService;
+import com.jinddung2.givemeticon.mail.application.MailVerifyService;
 import com.jinddung2.givemeticon.mail.presentation.request.EmailCertificationRequest;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.security.NoSuchAlgorithmException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/mails")
 public class MailController {
 
     private final MailSendService mailSendService;
+    private final MailVerifyService mailVerifyService;
 
     @PostMapping("/send-certification")
     public ResponseEntity<ApiResponse<Void>> sendCertificationNumber(@Validated @RequestBody EmailCertificationRequest request)
             throws MessagingException, NoSuchAlgorithmException {
         mailSendService.sendEmailForCertification(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success());
+    }
+
+    @GetMapping("/verify")
+    public ResponseEntity<ApiResponse<Void>> verifyCertificationNumber(
+            @RequestParam(name = "email") String email,
+            @RequestParam(name = "certificationNumber") String certificationNumber
+    ) {
+        mailVerifyService.verifyEmail(email, certificationNumber);
         return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
@@ -24,8 +24,8 @@ public class MailController {
     @PostMapping("/send-certification")
     public ResponseEntity<ApiResponse<EmailCertificationResponse>> sendCertificationNumber(@Validated @RequestBody EmailCertificationRequest request)
             throws MessagingException, NoSuchAlgorithmException {
-        mailSendService.sendEmailForCertification(request.getEmail());
-        return ResponseEntity.ok(ApiResponse.success());
+        EmailCertificationResponse response = mailSendService.sendEmailForCertification(request.getEmail());
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/verify")

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/MailController.java
@@ -4,6 +4,7 @@ import com.jinddung2.givemeticon.common.response.ApiResponse;
 import com.jinddung2.givemeticon.mail.application.MailSendService;
 import com.jinddung2.givemeticon.mail.application.MailVerifyService;
 import com.jinddung2.givemeticon.mail.presentation.request.EmailCertificationRequest;
+import com.jinddung2.givemeticon.mail.presentation.response.EmailCertificationResponse;
 import jakarta.mail.MessagingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +22,7 @@ public class MailController {
     private final MailVerifyService mailVerifyService;
 
     @PostMapping("/send-certification")
-    public ResponseEntity<ApiResponse<Void>> sendCertificationNumber(@Validated @RequestBody EmailCertificationRequest request)
+    public ResponseEntity<ApiResponse<EmailCertificationResponse>> sendCertificationNumber(@Validated @RequestBody EmailCertificationRequest request)
             throws MessagingException, NoSuchAlgorithmException {
         mailSendService.sendEmailForCertification(request.getEmail());
         return ResponseEntity.ok(ApiResponse.success());

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/request/EmailCertificationRequest.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/request/EmailCertificationRequest.java
@@ -1,0 +1,19 @@
+package com.jinddung2.givemeticon.mail.presentation.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class EmailCertificationRequest {
+
+    @NotBlank(message = "이메일 입력은 필수입니다.")
+    @Email(message = "이메일 형식에 맞게 입력해 주세요.")
+    private String email;
+}

--- a/src/main/java/com/jinddung2/givemeticon/mail/presentation/response/EmailCertificationResponse.java
+++ b/src/main/java/com/jinddung2/givemeticon/mail/presentation/response/EmailCertificationResponse.java
@@ -1,0 +1,13 @@
+package com.jinddung2.givemeticon.mail.presentation.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EmailCertificationResponse {
+    private String email;
+    private String certificationNumber;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,8 @@ spring:
     properties:
       mail:
         debug: true
-        stmp.auth: true
-        stmp.timeout: 50000
+        smtp.auth: true
+        smtp.timeout: 50000
         smtp.starttls.enable: true
 
 mybatis:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,9 @@ mybatis:
   type-aliases-package: com.jinddung2.givemeticon.*.domain
   configuration:
     map-underscore-to-camel-case: true
+
+mail:
+  title:
+    certification: givemeticon 인증번호 안내
+  domain:
+    name: http://localhost:8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,6 +7,15 @@ spring:
 
   profiles:
     include: secret
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        debug: true
+        stmp.auth: true
+        stmp.timeout: 50000
+        smtp.starttls.enable: true
 
 mybatis:
   mapper-locations: classpath:mapper/**/*.xml

--- a/src/test/java/com/jinddung2/givemeticon/mail/application/MailSendServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/mail/application/MailSendServiceTest.java
@@ -1,0 +1,64 @@
+package com.jinddung2.givemeticon.mail.application;
+
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationGenerator;
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
+import com.jinddung2.givemeticon.mail.presentation.response.EmailCertificationResponse;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mail.javamail.JavaMailSender;
+
+import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MailSendServiceTest {
+
+    @InjectMocks
+    MailSendService mailSendService;
+    @Mock
+    JavaMailSender mailSender;
+
+    @Mock
+    CertificationNumberDao certificationNumberDao;
+
+    @Mock
+    CertificationGenerator generator;
+
+    @BeforeEach
+    void setUp() {
+        mailSendService = new MailSendService(mailSender, certificationNumberDao, generator);
+    }
+
+    @Test
+    @DisplayName("이메일 보내기")
+    void sendEmailForCertification() throws NoSuchAlgorithmException, MessagingException {
+        // given
+        String email = "test@example.com";
+        String certificationNumber = "123456";
+
+        MimeMessage mimeMessage = new MimeMessage(Session.getDefaultInstance(new Properties()));
+        when(mailSender.createMimeMessage()).thenReturn(mimeMessage);
+        when(generator.createCertificationNumber()).thenReturn(certificationNumber);
+
+        // when
+        EmailCertificationResponse response = mailSendService.sendEmailForCertification(email);
+
+        verify(mailSender).send(any(MimeMessage.class));
+        verify(certificationNumberDao).saveCertificationNumber(email, certificationNumber);
+
+        assertEquals(email, response.getEmail());
+        assertEquals(certificationNumber, response.getCertificationNumber());
+    }
+
+}

--- a/src/test/java/com/jinddung2/givemeticon/mail/application/MailVerifyServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/mail/application/MailVerifyServiceTest.java
@@ -1,0 +1,69 @@
+package com.jinddung2.givemeticon.mail.application;
+
+import com.jinddung2.givemeticon.mail.exception.EmailNotFoundException;
+import com.jinddung2.givemeticon.mail.exception.InvalidCertificationNumberException;
+import com.jinddung2.givemeticon.mail.infrastructure.CertificationNumberDao;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MailVerifyServiceTest {
+    @InjectMocks
+    MailVerifyService mailVerifyService;
+
+    @Mock
+    CertificationNumberDao certificationNumberDao;
+
+    String email;
+    String certificationNumber;
+    String invalidCertificationNumber;
+
+    @BeforeEach
+    void setUp() {
+        email = "test@example.com";
+        certificationNumber = "123456";
+        invalidCertificationNumber = "999999";
+    }
+
+    @Test
+    @DisplayName("유효한 인증번호 검증")
+    void verifyEmail_ValidCertification() {
+
+        when(certificationNumberDao.hasKey(email)).thenReturn(true);
+        when(certificationNumberDao.getCertificationNumber(email)).thenReturn(certificationNumber);
+
+        assertDoesNotThrow(() -> mailVerifyService.verifyEmail(email, certificationNumber));
+
+        verify(certificationNumberDao).removeCertificationNumber(email);
+    }
+
+    @Test
+    @DisplayName("유효하지 않는 인증번호 테스트")
+    void verifyEmail_InvalidCertification() {
+
+        when(certificationNumberDao.hasKey(email)).thenReturn(true);
+        when(certificationNumberDao.getCertificationNumber(email)).thenReturn(certificationNumber);
+
+        assertThrows(InvalidCertificationNumberException.class, () -> mailVerifyService.verifyEmail(email, invalidCertificationNumber));
+    }
+
+    @Test
+    @DisplayName("해당 이메일 주소에 대한 인증번호가 없는 경우")
+    void verifyEmail_CertificationNotFound() {
+
+        when(certificationNumberDao.hasKey(email)).thenReturn(false);
+
+        assertThrows(EmailNotFoundException.class, () -> mailVerifyService.verifyEmail(email, certificationNumber));
+    }
+
+}

--- a/src/test/java/com/jinddung2/givemeticon/mail/presentation/MailControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/mail/presentation/MailControllerTest.java
@@ -1,0 +1,61 @@
+package com.jinddung2.givemeticon.mail.presentation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jinddung2.givemeticon.mail.application.MailSendService;
+import com.jinddung2.givemeticon.mail.application.MailVerifyService;
+import com.jinddung2.givemeticon.mail.presentation.response.EmailCertificationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@WebMvcTest(MailController.class)
+class MailControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    MailSendService mailSendService;
+
+    @MockBean
+    MailVerifyService mailVerifyService;
+
+    String email;
+    String certificationNumber;
+
+    @BeforeEach
+    void setUp() {
+        email = "test@example.com";
+        certificationNumber = "123456";
+    }
+
+    @Test
+    public void testSendCertificationNumber() throws Exception {
+        EmailCertificationResponse response = new EmailCertificationResponse(email, certificationNumber);
+        Mockito.when(mailSendService.sendEmailForCertification(Mockito.anyString()))
+                .thenReturn(response);
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/mails/send-certification")
+                        .content("{\"email\":\"test@example.com\"}")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+
+    @Test
+    public void testVerifyCertificationNumber() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/mails/verify")
+                        .param("email", "test@example.com")
+                        .param("certificationNumber", "123456"))
+                .andExpect(MockMvcResultMatchers.status().isOk());
+    }
+}

--- a/src/test/java/com/jinddung2/givemeticon/mail/presentation/MailControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/mail/presentation/MailControllerTest.java
@@ -3,17 +3,23 @@ package com.jinddung2.givemeticon.mail.presentation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jinddung2.givemeticon.mail.application.MailSendService;
 import com.jinddung2.givemeticon.mail.application.MailVerifyService;
+import com.jinddung2.givemeticon.mail.exception.EmailNotFoundException;
+import com.jinddung2.givemeticon.mail.exception.InvalidCertificationNumberException;
 import com.jinddung2.givemeticon.mail.presentation.response.EmailCertificationResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(MailController.class)
 class MailControllerTest {
@@ -40,22 +46,48 @@ class MailControllerTest {
     }
 
     @Test
-    public void testSendCertificationNumber() throws Exception {
+    public void send_CertificationNumber_Success() throws Exception {
         EmailCertificationResponse response = new EmailCertificationResponse(email, certificationNumber);
-        Mockito.when(mailSendService.sendEmailForCertification(Mockito.anyString()))
+        when(mailSendService.sendEmailForCertification(anyString()))
                 .thenReturn(response);
 
         mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/mails/send-certification")
                         .content("{\"email\":\"test@example.com\"}")
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                .andExpect(status().isOk());
     }
 
     @Test
-    public void testVerifyCertificationNumber() throws Exception {
+    public void verify_CertificationNumber_Success() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/mails/verify")
-                        .param("email", "test@example.com")
-                        .param("certificationNumber", "123456"))
-                .andExpect(MockMvcResultMatchers.status().isOk());
+                        .param("email", email)
+                        .param("certificationNumber", certificationNumber))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void verify_CertificationNumber_Fail_Email_Not_Exists() throws Exception {
+        doThrow(new EmailNotFoundException()).when(mailVerifyService).verifyEmail(email, certificationNumber);
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/mails/verify")
+                .param("email", "test@example.com")
+                .param("certificationNumber", "123456"));
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("이메일이 존재하지 않습니다."));
+    }
+
+    @Test
+    public void verify_CertificationNumber_Fail_Invalid_Certificated_Number() throws Exception {
+        doThrow(new InvalidCertificationNumberException()).when(mailVerifyService).verifyEmail(email, certificationNumber);
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/mails/verify")
+                .param("email", "test@example.com")
+                .param("certificationNumber", "123456"));
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("인증 번호가 다릅니다."));
     }
 }


### PR DESCRIPTION
## 작업 요약

- 회원가입 시 필요한 이메일 인증

## 작업 내용

- [x] 인증코드를 위한 난수 생성
- [x] 인증코드 레디스에 저장
- [x] 인증코드 일치 확인
- [x] 이메일을 찾지 못할 경우, 인증코드가 일치하지 않은 경우 예외처리
