### PR TITLE
메서드 리팩토링

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
+++ b/src/main/java/com/jinddung2/givemeticon/common/exception/ErrorCode.java
@@ -33,7 +33,11 @@ public enum ErrorCode {
     NOT_FOUND_SALE("존재하지 않는 판매 상품입니다."),
     NOT_REGISTER_ACCOUNT("판매자 등록이 되어 있지 않습니다."),
     EXPIRED_DATE("유효기간이 이미 지났습니다."),
-    DUPLICATED_BARCODE_NUMBER("이미 등록된 바코드 입니다.");
+    DUPLICATED_BARCODE_NUMBER("이미 등록된 바코드 입니다."),
+
+    // Trade
+    INVALID_DISCOUNT_RATE("할인율은 0 이상 1 이하여야 합니다."),
+    ALREADY_BOUGHT_SALE("이미 구매된 상품 입니다.");
 
     private final String message;
 

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/controller/ItemController.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/controller/ItemController.java
@@ -26,8 +26,8 @@ public class ItemController {
     }
 
     @GetMapping("/{itemId}")
-    public ResponseEntity<ApiResponse<ItemDto>> getItem(@PathVariable("itemId") int itemId) {
-        ItemDto itemDto = itemService.getItem(itemId);
+    public ResponseEntity<ApiResponse<ItemDto>> getItemAndIncreaseViewCount(@PathVariable("itemId") int itemId) {
+        ItemDto itemDto = itemService.getItemAndIncreaseViewCount(itemId);
         return new ResponseEntity<>(ApiResponse.success(itemDto), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
@@ -20,10 +20,14 @@ public class ItemService {
     }
 
     public ItemDto getItem(int itemId) {
-        Item item = itemMapper.findById(itemId).orElseThrow(NotFoundItemException::new);
+        Item item = validateItem(itemId);
         item.increaseViewCount();
         itemMapper.increaseViewCount(itemId);
         return ItemDto.of(item);
+    }
+
+    public Item validateItem(int itemId) {
+        return itemMapper.findById(itemId).orElseThrow(NotFoundItemException::new);
     }
 
     public boolean isExists(int itemId) {

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
@@ -19,15 +19,15 @@ public class ItemService {
         return itemMapper.save(item);
     }
 
-    public ItemDto getItem(int itemId) {
-        Item item = validateItem(itemId);
+    public Item getItem(int itemId) {
+        return itemMapper.findById(itemId).orElseThrow(NotFoundItemException::new);
+    }
+
+    public ItemDto getItemAndIncreaseViewCount(int itemId) {
+        Item item = getItem(itemId);
         item.increaseViewCount();
         itemMapper.increaseViewCount(itemId);
         return ItemDto.of(item);
-    }
-
-    public Item validateItem(int itemId) {
-        return itemMapper.findById(itemId).orElseThrow(NotFoundItemException::new);
     }
 
     public boolean isExists(int itemId) {

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/controller/SaleController.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/controller/SaleController.java
@@ -32,14 +32,14 @@ public class SaleController {
     }
 
     @GetMapping("/{saleId}")
-    public ResponseEntity<ApiResponse<SaleDto>> getSale(@PathVariable("saleId") int saleId) {
-        SaleDto saleDto = saleService.getSale(saleId);
+    public ResponseEntity<ApiResponse<SaleDto>> getAvailableSaleForItem(@PathVariable("saleId") int saleId) {
+        SaleDto saleDto = saleService.getAvailableSaleForItem(saleId);
         return new ResponseEntity<>(ApiResponse.success(saleDto), HttpStatus.OK);
     }
 
     @GetMapping("/items/{itemId}")
-    public ResponseEntity<ApiResponse<List<SaleDto>>> getSalesByItemId(@PathVariable("itemId") int itemId) {
-        List<SaleDto> sales = saleItemFacade.getSalesByItemId(itemId);
+    public ResponseEntity<ApiResponse<List<SaleDto>>> getSalesForItem(@PathVariable("itemId") int itemId) {
+        List<SaleDto> sales = saleItemFacade.getSalesForItem(itemId);
         return new ResponseEntity<>(ApiResponse.success(sales), HttpStatus.OK);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/domain/Sale.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/domain/Sale.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -18,7 +19,7 @@ public class Sale {
     private String barcode;
     private LocalDate expirationDate;
     private boolean isBought;
-    private LocalDate isBoughtDate;
+    private Date isBoughtDate;
     private LocalDateTime createdDate;
     private LocalDateTime updatedDate;
     private LocalDateTime deletedDate;
@@ -30,7 +31,7 @@ public class Sale {
                 String barcode,
                 LocalDate expirationDate,
                 boolean isBought,
-                LocalDate isBoughtDate,
+                Date isBoughtDate,
                 LocalDateTime createdDate,
                 LocalDateTime updatedDate,
                 LocalDateTime deletedDate
@@ -53,5 +54,10 @@ public class Sale {
 
     public void updateSellerId(int sellerId) {
         this.sellerId = sellerId;
+    }
+
+    public void updateBoughtState() {
+        this.isBought = true;
+        this.isBoughtDate = Date.valueOf(LocalDate.now());
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/dto/SaleDto.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/dto/SaleDto.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -18,11 +19,11 @@ public class SaleDto {
     private String barcode;
     private LocalDate expirationDate;
     private boolean isBought;
-    private LocalDate isBoughtDate;
+    private Date isBoughtDate;
     private LocalDateTime createdDate;
 
     @Builder
-    public SaleDto(int id, int itemId, int sellerId, String barcode, LocalDate expirationDate, boolean isBought, LocalDate isBoughtDate, LocalDateTime createdDate, LocalDateTime updatedDate) {
+    public SaleDto(int id, int itemId, int sellerId, String barcode, LocalDate expirationDate, boolean isBought, Date isBoughtDate, LocalDateTime createdDate) {
         this.id = id;
         this.itemId = itemId;
         this.sellerId = sellerId;

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacade.java
@@ -1,5 +1,6 @@
 package com.jinddung2.givemeticon.domain.sale.facade;
 
+import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.service.ItemService;
 import com.jinddung2.givemeticon.domain.sale.dto.SaleDto;
 import com.jinddung2.givemeticon.domain.sale.service.SaleService;
@@ -15,8 +16,8 @@ public class SaleItemFacade {
     private final ItemService itemService;
     private final SaleService saleService;
 
-    public List<SaleDto> getSalesByItemId(int itemId) {
-        itemService.getItem(itemId);
-        return saleService.getSalesByItemId(itemId);
+    public List<SaleDto> getSalesForItem(int itemId) {
+        Item item = itemService.getItem(itemId);
+        return saleService.getAvailableSalesForItem(item);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
@@ -11,6 +11,8 @@ public interface SaleMapper {
 
     int save(Sale itemVariant);
 
+    int update(Sale sale);
+
     boolean existsByBarcode(String barcode);
 
     Optional<Sale> findById(int saleId);

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
@@ -11,11 +11,11 @@ public interface SaleMapper {
 
     int save(Sale itemVariant);
 
-    int update(Sale sale);
+    void update(Sale sale);
 
     boolean existsByBarcode(String barcode);
 
     Optional<Sale> findById(int saleId);
 
-    List<Sale> findSalesByItemId(int itemId);
+    List<Sale> findNotBoughtSalesByItemId(int itemId);
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
@@ -37,13 +37,17 @@ public class SaleService {
     }
 
     public SaleDto getSale(int saleId) {
-        Sale sale = saleMapper.findById(saleId).orElseThrow(NotFoundSaleException::new);
+        Sale sale = validateSale(saleId);
 
         if (sale.getExpirationDate().isBefore(LocalDate.now())) {
             throw new ExpiredSaleException();
         }
 
         return SaleDto.of(sale);
+    }
+
+    public Sale validateSale(int saleId) {
+        return saleMapper.findById(saleId).orElseThrow(NotFoundSaleException::new);
     }
 
     public List<SaleDto> getSalesByItemId(int itemId) {

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
@@ -9,6 +9,8 @@ import com.jinddung2.givemeticon.domain.sale.exception.NotFoundSaleException;
 import com.jinddung2.givemeticon.domain.sale.mapper.SaleMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -30,6 +32,7 @@ public class SaleService {
         return itemVariant.getId();
     }
 
+    @Transactional(propagation = Propagation.REQUIRED)
     public int update(Sale sale) {
         saleMapper.update(sale);
         return sale.getId();

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
@@ -1,5 +1,6 @@
 package com.jinddung2.givemeticon.domain.sale.service;
 
+import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.sale.controller.request.SaleCreateRequest;
 import com.jinddung2.givemeticon.domain.sale.domain.Sale;
 import com.jinddung2.givemeticon.domain.sale.dto.SaleDto;
@@ -7,6 +8,7 @@ import com.jinddung2.givemeticon.domain.sale.exception.DuplicatedBarcodeExceptio
 import com.jinddung2.givemeticon.domain.sale.exception.ExpiredSaleException;
 import com.jinddung2.givemeticon.domain.sale.exception.NotFoundSaleException;
 import com.jinddung2.givemeticon.domain.sale.mapper.SaleMapper;
+import com.jinddung2.givemeticon.domain.trade.exception.AlreadyBoughtSaleException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -44,8 +46,16 @@ public class SaleService {
         }
     }
 
-    public SaleDto getSale(int saleId) {
-        Sale sale = validateSale(saleId);
+    public Sale getSale(int saleId) {
+        return saleMapper.findById(saleId).orElseThrow(NotFoundSaleException::new);
+    }
+
+    public SaleDto getAvailableSaleForItem(int saleId) {
+        Sale sale = getSale(saleId);
+
+        if (sale.isBought() && sale.getIsBoughtDate() != null) {
+            throw new AlreadyBoughtSaleException();
+        }
 
         if (sale.getExpirationDate().isBefore(LocalDate.now())) {
             throw new ExpiredSaleException();
@@ -54,12 +64,8 @@ public class SaleService {
         return SaleDto.of(sale);
     }
 
-    public Sale validateSale(int saleId) {
-        return saleMapper.findById(saleId).orElseThrow(NotFoundSaleException::new);
-    }
-
-    public List<SaleDto> getSalesByItemId(int itemId) {
-        List<Sale> sales = saleMapper.findSalesByItemId(itemId);
+    public List<SaleDto> getAvailableSalesForItem(Item item) {
+        List<Sale> sales = saleMapper.findNotBoughtSalesByItemId(item.getId());
         return sales.stream()
                 .filter(sale -> !sale.getExpirationDate().isBefore(LocalDate.now()))
                 .map(SaleDto::of)

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
@@ -30,6 +30,11 @@ public class SaleService {
         return itemVariant.getId();
     }
 
+    public int update(Sale sale) {
+        saleMapper.update(sale);
+        return sale.getId();
+    }
+
     public void validateDuplicateBarcode(String barcode) {
         if (saleMapper.existsByBarcode(barcode)) {
             throw new DuplicatedBarcodeException();

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/advice/TradeExceptionAdvice.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/advice/TradeExceptionAdvice.java
@@ -1,0 +1,21 @@
+package com.jinddung2.givemeticon.domain.trade.advice;
+
+import com.jinddung2.givemeticon.common.response.ApiResponse;
+import com.jinddung2.givemeticon.common.response.ErrorResult;
+import com.jinddung2.givemeticon.domain.trade.exception.TradeException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class TradeExceptionAdvice {
+    @ExceptionHandler(TradeException.class)
+    public ResponseEntity<ApiResponse<ErrorResult>> handleItemException(TradeException e) {
+        ErrorResult errorResult = new ErrorResult(e.getMessage());
+        log.debug("Trade exception!! error msg={}", errorResult);
+        return new ResponseEntity<>(ApiResponse.fail(errorResult), HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/controller/TradeController.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/controller/TradeController.java
@@ -1,0 +1,27 @@
+package com.jinddung2.givemeticon.domain.trade.controller;
+
+import com.jinddung2.givemeticon.common.response.ApiResponse;
+import com.jinddung2.givemeticon.domain.trade.facade.TradeCreationFacade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/trades")
+public class TradeController {
+
+    private final TradeCreationFacade tradeCreationFacade;
+
+    @PostMapping("/sales/{saleId}/buyer/{buyerId}")
+    public ResponseEntity<ApiResponse<Integer>> createTrade(@PathVariable("saleId") int saleId,
+                                                            @PathVariable("buyerId") int buyerId) {
+        int id = tradeCreationFacade.transact(saleId, buyerId);
+        return new ResponseEntity<>(ApiResponse.success(id), HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/domain/DiscountRatePolicy.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/domain/DiscountRatePolicy.java
@@ -1,0 +1,13 @@
+package com.jinddung2.givemeticon.domain.trade.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum DiscountRatePolicy {
+    STANDARD(0.10),
+    WEEKLY_DISCOUNT(0.15);
+
+    private final double discountRate;
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/domain/Trade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/domain/Trade.java
@@ -1,0 +1,43 @@
+package com.jinddung2.givemeticon.domain.trade.domain;
+
+import com.jinddung2.givemeticon.domain.trade.exception.InvalidDiscountRateException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class Trade {
+    private int id;
+    private int buyerId;
+    private int saleId;
+    private BigDecimal salePrice;
+    private boolean isUsed;
+    private LocalDate isUsedDate;
+    private LocalDate createdDate;
+
+    @Builder
+    public Trade(int id, int buyerId, int saleId, BigDecimal salePrice, boolean isUsed, LocalDate isUsedDate, LocalDate createdDate) {
+        this.id = id;
+        this.buyerId = buyerId;
+        this.saleId = saleId;
+        this.salePrice = salePrice;
+        this.isUsed = isUsed;
+        this.isUsedDate = isUsedDate;
+        this.createdDate = createdDate;
+    }
+
+    public void discountItemPrice(double discountRate) {
+        if (discountRate < 0 || discountRate > 1) {
+            throw new InvalidDiscountRateException();
+        }
+
+        BigDecimal discountPrice = salePrice.multiply(BigDecimal.valueOf(discountRate))
+                .setScale(0, RoundingMode.HALF_UP);
+        this.salePrice = salePrice.subtract(discountPrice);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/AlreadyBoughtSaleException.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/AlreadyBoughtSaleException.java
@@ -1,0 +1,10 @@
+package com.jinddung2.givemeticon.domain.trade.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+
+public class AlreadyBoughtSaleException extends TradeException {
+
+    public AlreadyBoughtSaleException() {
+        super(ErrorCode.ALREADY_BOUGHT_SALE);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/InvalidDiscountRateException.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/InvalidDiscountRateException.java
@@ -1,0 +1,10 @@
+package com.jinddung2.givemeticon.domain.trade.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+
+public class InvalidDiscountRateException extends TradeException {
+
+    public InvalidDiscountRateException() {
+        super(ErrorCode.INVALID_DISCOUNT_RATE);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/TradeException.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/exception/TradeException.java
@@ -1,0 +1,10 @@
+package com.jinddung2.givemeticon.domain.trade.exception;
+
+import com.jinddung2.givemeticon.common.exception.ErrorCode;
+import com.jinddung2.givemeticon.common.exception.GiveMeTiConException;
+
+public class TradeException extends GiveMeTiConException {
+    public TradeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
@@ -28,7 +28,7 @@ public class TradeCreationFacade {
     @Transactional
     public int transact(int saleId, int buyerId) {
         userService.validateUser(buyerId);
-        Sale sale = saleService.validateSale(saleId);
+        Sale sale = saleService.getSale(saleId);
 
         if (sale.isBought()) {
             throw new AlreadyBoughtSaleException();

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
@@ -34,7 +34,7 @@ public class TradeCreationFacade {
             throw new AlreadyBoughtSaleException();
         }
 
-        Item item = itemService.validateItem(sale.getItemId());
+        Item item = itemService.getItem(sale.getItemId());
 
         long daysUntilExpiration = ChronoUnit.DAYS.between(LocalDate.now(), sale.getExpirationDate());
 

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacade.java
@@ -1,0 +1,52 @@
+package com.jinddung2.givemeticon.domain.trade.facade;
+
+import com.jinddung2.givemeticon.domain.item.domain.Item;
+import com.jinddung2.givemeticon.domain.item.service.ItemService;
+import com.jinddung2.givemeticon.domain.sale.domain.Sale;
+import com.jinddung2.givemeticon.domain.sale.service.SaleService;
+import com.jinddung2.givemeticon.domain.trade.domain.Trade;
+import com.jinddung2.givemeticon.domain.trade.exception.AlreadyBoughtSaleException;
+import com.jinddung2.givemeticon.domain.trade.service.TradeService;
+import com.jinddung2.givemeticon.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TradeCreationFacade {
+
+    private final UserService userService;
+    private final SaleService saleService;
+    private final ItemService itemService;
+    private final TradeService tradeService;
+
+    @Transactional
+    public int transact(int saleId, int buyerId) {
+        userService.validateUser(buyerId);
+        Sale sale = saleService.validateSale(saleId);
+
+        if (sale.isBought()) {
+            throw new AlreadyBoughtSaleException();
+        }
+
+        Item item = itemService.validateItem(sale.getItemId());
+
+        long daysUntilExpiration = ChronoUnit.DAYS.between(LocalDate.now(), sale.getExpirationDate());
+
+        Trade trade = Trade.builder()
+                .buyerId(buyerId)
+                .saleId(saleId)
+                .salePrice(BigDecimal.valueOf(item.getPrice()))
+                .isUsed(false)
+                .build();
+
+        sale.updateBoughtState();
+        saleService.update(sale);
+        return tradeService.save(trade, daysUntilExpiration);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/mapper/TradeMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/mapper/TradeMapper.java
@@ -1,0 +1,9 @@
+package com.jinddung2.givemeticon.domain.trade.mapper;
+
+import com.jinddung2.givemeticon.domain.trade.domain.Trade;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface TradeMapper {
+    void save(Trade trade);
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/service/TradeService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/service/TradeService.java
@@ -1,0 +1,28 @@
+package com.jinddung2.givemeticon.domain.trade.service;
+
+import com.jinddung2.givemeticon.domain.trade.domain.Trade;
+import com.jinddung2.givemeticon.domain.trade.mapper.TradeMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.jinddung2.givemeticon.domain.trade.domain.DiscountRatePolicy.STANDARD;
+import static com.jinddung2.givemeticon.domain.trade.domain.DiscountRatePolicy.WEEKLY_DISCOUNT;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TradeService {
+
+    private final TradeMapper tradeMapper;
+
+    @Transactional(propagation = Propagation.REQUIRED)
+    public int save(Trade trade, long daysUntilExpiration) {
+        double discountRate = daysUntilExpiration > 7L ? STANDARD.getDiscountRate() : WEEKLY_DISCOUNT.getDiscountRate();
+        trade.discountItemPrice(discountRate);
+        tradeMapper.save(trade);
+        return trade.getId();
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/user/service/UserService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/user/service/UserService.java
@@ -35,7 +35,7 @@ public class UserService {
     }
 
     public UserDto getUserInfo(int userId) {
-        User user = getUser(userId);
+        User user = validateUser(userId);
         return UserDto.of(user);
     }
 
@@ -51,7 +51,7 @@ public class UserService {
     }
 
     public void updatePassword(int userId, PasswordUpdateRequest request) {
-        User user = getUser(userId);
+        User user = validateUser(userId);
 
         if (!user.isPasswordMatch(passwordEncoder, request.oldPassword())) {
             throw new MisMatchPasswordException();
@@ -63,20 +63,20 @@ public class UserService {
     }
 
     public void updateAccount(int userId, int accountId) {
-        User user = getUser(userId);
+        User user = validateUser(userId);
         user.createAccount(accountId);
         log.info("user={}", user);
         userMapper.updateAccount(userId, accountId);
     }
 
     public void resetPassword(String email, String tempPassword) {
-        User user = getUser(email);
+        User user = validateUser(email);
         String encryptedPassword = passwordEncoder.encode(tempPassword);
         user.updatePassword(encryptedPassword);
         userMapper.updatePassword(user.getId(), encryptedPassword);
     }
 
-    private User getUser(int userId) {
+    public User validateUser(int userId) {
         return userMapper.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
     }
@@ -91,7 +91,7 @@ public class UserService {
         }
     }
 
-    private User getUser(String email) {
+    private User validateUser(String email) {
         return userMapper.findByEmail(email)
                 .orElseThrow(NotFoundEmailException::new);
     }

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -26,6 +26,25 @@
                 null)
     </insert>
 
+    <update id="update" parameterType="Sale">
+        UPDATE sale
+        SET item_id = #{itemId},
+        seller_id = #{sellerId},
+        barcode = #{barcode},
+        expiration_date = #{expirationDate},
+        is_bought = #{isBought},
+        is_bought_date = #{isBoughtDate},
+        created_date = #{createdDate},
+        updated_date = #{updatedDate},
+        <if test="deletedDate == null">
+            deleted_date = null
+        </if>
+        <if test="deletedDate != null">
+            deleted_date = deleted_date
+        </if>
+        WHERE id = #{id}
+    </update>
+
     <select id="existsByBarcode" parameterType="String" resultType="boolean">
         SELECT EXISTS
                    (SELECT 1 FROM sale WHERE barcode = #{barcode})

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -61,11 +61,9 @@
                created_date
         FROM sale
         WHERE id = #{saleId}
-          AND is_bought = 0
-          AND is_bought_date IS NULL
     </select>
 
-    <select id="findSalesByItemId" parameterType="int" resultType="Sale">
+    <select id="findNotBoughtSalesByItemId" parameterType="int" resultType="Sale">
         SELECT id,
                item_id,
                seller_id,

--- a/src/main/resources/mapper/TradeMapper.xml
+++ b/src/main/resources/mapper/TradeMapper.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.jinddung2.givemeticon.domain.trade.mapper.TradeMapper">
+    <insert id="save" parameterType="Trade" useGeneratedKeys="true" keyProperty="id">
+        INSERT INTO trade (id,
+                           buyer_id,
+                           sale_id,
+                           sale_price,
+                           is_used,
+                           is_used_date,
+                           created_date)
+        VALUES (#{id},
+                #{buyerId},
+                #{saleId},
+                #{salePrice},
+                #{isUsed},
+                null,
+                NOW())
+    </insert>
+
+
+</mapper>

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/controller/ItemControllerTest.java
@@ -71,12 +71,12 @@ class ItemControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        Mockito.verify(itemService).getItem(id);
+        Mockito.verify(itemService).getItemAndIncreaseViewCount(id);
     }
 
     @Test
     void getItem_Fail_Not_Found_Item() throws Exception {
-        doThrow(new NotFoundItemException()).when(itemService).getItem(id);
+        doThrow(new NotFoundItemException()).when(itemService).getItemAndIncreaseViewCount(id);
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
                         .get("/api/v1/items/" + id)
                         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
@@ -34,13 +34,22 @@ class ItemServiceTest {
     }
 
     @Test
-    @DisplayName("전시용 아이템 조회에 성공한다.")
+    @DisplayName("아이템 도메인 조회에 성공한다.")
     void get_Item_Success() {
         Mockito.when(itemMapper.findById(item.getId())).thenReturn(Optional.of(item));
 
         itemService.getItem(item.getId());
 
-        Mockito.verify(item).increaseViewCount();
+        Mockito.verify(itemMapper).findById(item.getId());
+    }
+
+    @Test
+    @DisplayName("전시용 아이템 조회에 성공하여 조회수가 증가한다.")
+    void get_Item_Increase_View_Count_Success() {
+        Mockito.when(itemMapper.findById(item.getId())).thenReturn(Optional.of(item));
+
+        itemService.getItemAndIncreaseViewCount(item.getId());
+
         Mockito.verify(itemMapper).increaseViewCount(item.getId());
     }
 
@@ -50,7 +59,7 @@ class ItemServiceTest {
         Mockito.when(itemMapper.findById(item.getId())).thenReturn(Optional.empty());
 
         Assertions.assertThrows(NotFoundItemException.class,
-                () -> itemService.validateItem(item.getId()));
+                () -> itemService.getItem(item.getId()));
 
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
@@ -50,7 +50,7 @@ class ItemServiceTest {
         Mockito.when(itemMapper.findById(item.getId())).thenReturn(Optional.empty());
 
         Assertions.assertThrows(NotFoundItemException.class,
-                () -> itemService.getItem(item.getId()));
+                () -> itemService.validateItem(item.getId()));
 
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/sale/controller/SaleControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/sale/controller/SaleControllerTest.java
@@ -166,13 +166,13 @@ class SaleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        Mockito.verify(saleService).getSale(saleId);
+        Mockito.verify(saleService).getAvailableSaleForItem(saleId);
     }
 
     @Test
     void get_Sale_Fail_Not_Found_Sale() throws Exception {
         Mockito.doThrow(new NotFoundSaleException())
-                .when(saleService).getSale(saleId);
+                .when(saleService).getAvailableSaleForItem(saleId);
 
         String url = defaultUrl + "/" + saleId;
 
@@ -196,7 +196,7 @@ class SaleControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk());
 
-        Mockito.verify(saleItemFacade).getSalesByItemId(itemId);
+        Mockito.verify(saleItemFacade).getSalesForItem(itemId);
     }
 
     @Test
@@ -204,7 +204,7 @@ class SaleControllerTest {
         String url = defaultUrl + "/items/" + itemId;
 
         Mockito.doThrow(new NotFoundItemException())
-                .when(saleItemFacade).getSalesByItemId(itemId);
+                .when(saleItemFacade).getSalesForItem(itemId);
 
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
                         .get(url)

--- a/src/test/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacadeTest.java
@@ -1,6 +1,6 @@
 package com.jinddung2.givemeticon.domain.sale.facade;
 
-import com.jinddung2.givemeticon.domain.item.dto.ItemDto;
+import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.NotFoundItemException;
 import com.jinddung2.givemeticon.domain.item.service.ItemService;
 import com.jinddung2.givemeticon.domain.sale.dto.SaleDto;
@@ -28,17 +28,17 @@ class SaleItemFacadeTest {
     SaleService saleService;
 
     int itemId;
-    ItemDto itemDto;
+    Item item;
 
     @BeforeEach
     void setUp() {
         itemId = 10;
-        itemDto = ItemDto.builder().id(itemId).build();
+        item = Item.builder().id(itemId).build();
     }
 
     @Test
     void get_Sales_By_ItemId_Success() {
-        Mockito.when(itemService.getItem(itemId)).thenReturn(itemDto);
+        Mockito.when(itemService.getItem(itemId)).thenReturn(item);
         List<SaleDto> sales = List.of(
                 SaleDto.builder().expirationDate(LocalDate.now().plusDays(1)).build(),
                 SaleDto.builder().expirationDate(LocalDate.now().plusDays(1)).build(),

--- a/src/test/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/sale/facade/SaleItemFacadeTest.java
@@ -43,9 +43,9 @@ class SaleItemFacadeTest {
                 SaleDto.builder().expirationDate(LocalDate.now().plusDays(1)).build(),
                 SaleDto.builder().expirationDate(LocalDate.now().plusDays(1)).build(),
                 SaleDto.builder().expirationDate(LocalDate.now().plusDays(1)).build());
-        Mockito.when(saleService.getSalesByItemId(itemId)).thenReturn(sales);
+        Mockito.when(saleService.getAvailableSalesForItem(item)).thenReturn(sales);
 
-        List<SaleDto> result = saleItemFacade.getSalesByItemId(itemId);
+        List<SaleDto> result = saleItemFacade.getSalesForItem(itemId);
 
         Assertions.assertEquals(sales, result);
     }
@@ -56,7 +56,7 @@ class SaleItemFacadeTest {
                 .when(itemService).getItem(itemId);
 
         Assertions.assertThrows(NotFoundItemException.class,
-                () -> saleItemFacade.getSalesByItemId(itemId));
+                () -> saleItemFacade.getSalesForItem(itemId));
 
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/sale/service/SaleServiceTest.java
@@ -89,7 +89,7 @@ class SaleServiceTest {
         Mockito.when(saleMapper.findById(sale.getId())).thenReturn(Optional.empty());
 
         Assertions.assertThrows(NotFoundSaleException.class,
-                () -> saleService.getSale(sale.getId()));
+                () -> saleService.validateSale(sale.getId()));
     }
 
     @Test

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/controller/TradeControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/controller/TradeControllerTest.java
@@ -1,0 +1,70 @@
+package com.jinddung2.givemeticon.domain.trade.controller;
+
+import com.jinddung2.givemeticon.common.config.WebConfig;
+import com.jinddung2.givemeticon.common.security.interceptor.AuthInterceptor;
+import com.jinddung2.givemeticon.domain.trade.exception.AlreadyBoughtSaleException;
+import com.jinddung2.givemeticon.domain.trade.facade.TradeCreationFacade;
+import com.jinddung2.givemeticon.domain.user.service.LoginService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(value = TradeController.class,
+        excludeFilters = @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {
+                WebConfig.class,
+                AuthInterceptor.class,
+                LoginService.class
+        }))
+class TradeControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    TradeCreationFacade tradeCreationFacade;
+
+    String defaultUrl = "/api/v1/trades";
+    int saleId = 10;
+    int buyerId = 20;
+
+    @Test
+    @DisplayName("거래에 성공한다.")
+    void create_Trade() throws Exception {
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(defaultUrl + String.format("/sales/%d/buyer/%d", saleId, buyerId))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isCreated());
+
+        Mockito.verify(tradeCreationFacade).transact(saleId, buyerId);
+    }
+
+    @Test
+    @DisplayName("구매된 상품이라 거래에 실패한다.")
+    void create_Trade_Fail_Already_Bought() throws Exception {
+        Mockito.doThrow(new AlreadyBoughtSaleException())
+                .when(tradeCreationFacade).transact(saleId, buyerId);
+
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
+                        .post(defaultUrl + String.format("/sales/%d/buyer/%d", saleId, buyerId))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("FAIL"))
+                .andExpect(jsonPath("$.data.message").value("이미 구매된 상품 입니다."));
+    }
+}

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/domain/TradeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/domain/TradeTest.java
@@ -1,0 +1,34 @@
+package com.jinddung2.givemeticon.domain.trade.domain;
+
+import com.jinddung2.givemeticon.domain.trade.exception.InvalidDiscountRateException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+class TradeTest {
+
+    Trade trade = Trade.builder()
+            .salePrice(BigDecimal.valueOf(10000))
+            .build();
+
+    @Test
+    @DisplayName("할인율이 0보다 낮아 실패한다.")
+    public void discountItemPrice_Fail_discountRate_Under_Zero() {
+        double discountRate = -0.1;
+
+        Assertions.assertThrows(InvalidDiscountRateException.class,
+                () -> trade.discountItemPrice(discountRate));
+    }
+
+    @Test
+    @DisplayName("할인율이 1보다 높아 실패한다.")
+    public void discountItemPrice_Fail_discountRate_Over_One() {
+        double discountRate = 1.1;
+
+        Assertions.assertThrows(InvalidDiscountRateException.class,
+                () -> trade.discountItemPrice(discountRate));
+    }
+
+}

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
@@ -61,7 +61,7 @@ class TradeCreationFacadeTest {
     void transact() {
         Mockito.when(userService.validateUser(buyerId)).thenReturn(user);
         Mockito.when(saleService.validateSale(saleId)).thenReturn(sale);
-        Mockito.when(itemService.validateItem(itemId)).thenReturn(item);
+        Mockito.when(itemService.getItem(itemId)).thenReturn(item);
 
         Mockito.when(tradeService.save(Mockito.any(Trade.class), Mockito.any(Long.class))).thenReturn(1);
 

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
@@ -60,7 +60,7 @@ class TradeCreationFacadeTest {
     @DisplayName("거래에 성공한다.")
     void transact() {
         Mockito.when(userService.validateUser(buyerId)).thenReturn(user);
-        Mockito.when(saleService.validateSale(saleId)).thenReturn(sale);
+        Mockito.when(saleService.getSale(saleId)).thenReturn(sale);
         Mockito.when(itemService.getItem(itemId)).thenReturn(item);
 
         Mockito.when(tradeService.save(Mockito.any(Trade.class), Mockito.any(Long.class))).thenReturn(1);
@@ -83,7 +83,7 @@ class TradeCreationFacadeTest {
 
         Assertions.assertTrue(sale.isBought());
 
-        Mockito.when(saleService.validateSale(saleId)).thenReturn(sale);
+        Mockito.when(saleService.getSale(saleId)).thenReturn(sale);
 
         Assertions.assertThrows(AlreadyBoughtSaleException.class, () -> {
             tradeCreationFacade.transact(saleId, buyerId);

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeCreationFacadeTest.java
@@ -1,0 +1,92 @@
+package com.jinddung2.givemeticon.domain.trade.facade;
+
+import com.jinddung2.givemeticon.domain.item.domain.Item;
+import com.jinddung2.givemeticon.domain.item.service.ItemService;
+import com.jinddung2.givemeticon.domain.sale.domain.Sale;
+import com.jinddung2.givemeticon.domain.sale.service.SaleService;
+import com.jinddung2.givemeticon.domain.trade.domain.Trade;
+import com.jinddung2.givemeticon.domain.trade.exception.AlreadyBoughtSaleException;
+import com.jinddung2.givemeticon.domain.trade.service.TradeService;
+import com.jinddung2.givemeticon.domain.user.domain.User;
+import com.jinddung2.givemeticon.domain.user.service.UserService;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+
+@ExtendWith(MockitoExtension.class)
+class TradeCreationFacadeTest {
+
+    @InjectMocks
+    TradeCreationFacade tradeCreationFacade;
+
+    @Mock
+    UserService userService;
+    @Mock
+    SaleService saleService;
+    @Mock
+    ItemService itemService;
+    @Mock
+    TradeService tradeService;
+
+    int buyerId;
+    int saleId;
+    int itemId;
+
+    User user;
+
+    Sale sale;
+
+    Item item;
+
+    @BeforeEach
+    void setUp() {
+        buyerId = 1;
+        saleId = 2;
+        itemId = 3;
+        user = User.builder().id(buyerId).build();
+        sale = Sale.builder().id(saleId).itemId(itemId).isBought(false).expirationDate(LocalDate.now().plusDays(30)).build();
+        item = Item.builder().id(itemId).price(10000).build();
+    }
+
+    @Test
+    @DisplayName("거래에 성공한다.")
+    void transact() {
+        Mockito.when(userService.validateUser(buyerId)).thenReturn(user);
+        Mockito.when(saleService.validateSale(saleId)).thenReturn(sale);
+        Mockito.when(itemService.validateItem(itemId)).thenReturn(item);
+
+        Mockito.when(tradeService.save(Mockito.any(Trade.class), Mockito.any(Long.class))).thenReturn(1);
+
+
+        int transactId = tradeCreationFacade.transact(saleId, buyerId);
+
+        Assertions.assertEquals(1, transactId);
+        Assertions.assertTrue(sale.isBought());
+
+        Mockito.verify(saleService).update(sale);
+        Mockito.verify(tradeService).save(Mockito.any(Trade.class), Mockito.any(Long.class));
+    }
+
+    @Test
+    @DisplayName("이미 구매한 상품이라 거래에 실패한다.")
+    void transact_Fail_Already_Bought() {
+        sale = Mockito.mock(Sale.class);
+        Mockito.when(sale.isBought()).thenReturn(true);
+
+        Assertions.assertTrue(sale.isBought());
+
+        Mockito.when(saleService.validateSale(saleId)).thenReturn(sale);
+
+        Assertions.assertThrows(AlreadyBoughtSaleException.class, () -> {
+            tradeCreationFacade.transact(saleId, buyerId);
+        });
+    }
+}

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/service/TradeServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/service/TradeServiceTest.java
@@ -1,0 +1,76 @@
+package com.jinddung2.givemeticon.domain.trade.service;
+
+import com.jinddung2.givemeticon.domain.trade.domain.Trade;
+import com.jinddung2.givemeticon.domain.trade.mapper.TradeMapper;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+import static com.jinddung2.givemeticon.domain.trade.domain.DiscountRatePolicy.STANDARD;
+import static com.jinddung2.givemeticon.domain.trade.domain.DiscountRatePolicy.WEEKLY_DISCOUNT;
+
+@ExtendWith(MockitoExtension.class)
+class TradeServiceTest {
+
+    @InjectMocks
+    TradeService tradeService;
+
+    @Mock
+    TradeMapper tradeMapper;
+
+    Trade trade;
+    int saleId, buyerId, price;
+
+    @BeforeEach
+    void setUp() {
+        saleId = 10;
+        buyerId = 20;
+        price = 10000;
+        trade = Trade.builder()
+                .saleId(saleId)
+                .buyerId(buyerId)
+                .salePrice(new BigDecimal(price))
+                .build();
+    }
+
+    @Test
+    @DisplayName("10% 할인된 가격으로 거래 데이터 저장한다.")
+    void save_10PER_Discount_Trade() {
+        double discountRate = STANDARD.getDiscountRate();
+        BigDecimal salePrice = BigDecimal.valueOf(price);
+
+        tradeService.save(trade, 8L);
+
+        BigDecimal discount = salePrice.multiply(BigDecimal.valueOf(discountRate))
+                .setScale(0, RoundingMode.HALF_UP);
+        BigDecimal result = salePrice.subtract(discount);
+
+        Assertions.assertEquals(result, trade.getSalePrice());
+        Mockito.verify(tradeMapper).save(trade);
+    }
+
+    @Test
+    @DisplayName("15% 할인된 가격으로 거래 데이터 저장한다.")
+    void save_15PER_Discount_Trade() {
+        double discountRate = WEEKLY_DISCOUNT.getDiscountRate();
+        BigDecimal salePrice = BigDecimal.valueOf(price);
+
+        tradeService.save(trade, 7L);
+
+        BigDecimal discount = salePrice.multiply(BigDecimal.valueOf(discountRate))
+                .setScale(0, RoundingMode.HALF_UP);
+        BigDecimal result = salePrice.subtract(discount);
+
+        Assertions.assertEquals(result, trade.getSalePrice());
+        Mockito.verify(tradeMapper).save(trade);
+    }
+}

--- a/src/test/java/com/jinddung2/givemeticon/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/user/service/UserServiceTest.java
@@ -97,7 +97,7 @@ class UserServiceTest {
     void get_User_Fail_Not_Exists_Email() {
         when(userMapper.findById(testUser.getId())).thenReturn(Optional.empty());
 
-        assertThrows(NotFoundUserException.class, () -> userService.getUserInfo(testUser.getId()));
+        assertThrows(NotFoundUserException.class, () -> userService.validateUser(testUser.getId()));
     }
 
     @Test


### PR DESCRIPTION
## 작업 요약

- getItem() 메서드 역할 분리: 아이템 정보 조회와 아이템 정보 조회와 함께 조회수 증가 기능 분리
- validate 보다는 도메인을 가져오는 메서드명은 getXXX()로 하기
- 판매 도메인 가져오기, 판매 가능한 도메인 가져오기 분리