### PR TITLE
[fix] 상품 중복 구매 문제 해결

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/mapper/SaleMapper.java
@@ -15,6 +15,8 @@ public interface SaleMapper {
 
     void update(Sale sale);
 
+    int updateBoughtStateIfNotBought(@Param("saleId") int saleId);
+
     boolean existsByBarcode(String barcode);
 
     Optional<Sale> findById(int saleId);

--- a/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/sale/service/SaleService.java
@@ -42,6 +42,13 @@ public class SaleService {
         return sale.getId();
     }
 
+    public void markAsBoughtIfAvailable(int saleId) {
+        int updatedRows = saleMapper.updateBoughtStateIfNotBought(saleId);
+        if (updatedRows != 1) {
+            throw new AlreadyBoughtSaleException();
+        }
+    }
+
     public void validateDuplicateBarcode(String barcode) {
         if (saleMapper.existsByBarcode(barcode)) {
             throw new DuplicatedBarcodeException();

--- a/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeWriteFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/trade/facade/TradeWriteFacade.java
@@ -7,7 +7,6 @@ import com.jinddung2.givemeticon.domain.notification.producer.NotificationProduc
 import com.jinddung2.givemeticon.domain.sale.domain.Sale;
 import com.jinddung2.givemeticon.domain.sale.service.SaleService;
 import com.jinddung2.givemeticon.domain.trade.domain.Trade;
-import com.jinddung2.givemeticon.domain.trade.exception.AlreadyBoughtSaleException;
 import com.jinddung2.givemeticon.domain.trade.service.TradeService;
 import io.micrometer.core.annotation.Timed;
 import lombok.RequiredArgsConstructor;
@@ -27,16 +26,11 @@ public class TradeWriteFacade {
     @Transactional
     public int transact(int saleId, int buyerId) {
         Sale sale = saleService.getSale(saleId);
-
-        if (sale.isBought()) {
-            throw new AlreadyBoughtSaleException();
-        }
+        saleService.markAsBoughtIfAvailable(saleId);
 
         Item item = itemService.getItem(sale.getItemId());
         int tradeId = tradeService.save(sale, item, buyerId);
 
-        sale.updateBoughtState();
-        saleService.update(sale);
         producer.create(new CreateNotificationRequestDto(saleId, sale.getSellerId(),
                 String.format("%s이(가) 판매되었습니다.", item.getName())));
 

--- a/src/main/resources/mapper/SaleMapper.xml
+++ b/src/main/resources/mapper/SaleMapper.xml
@@ -56,6 +56,15 @@
         WHERE id = #{id}
     </update>
 
+    <update id="updateBoughtStateIfNotBought" parameterType="int">
+        UPDATE sale
+        SET is_bought = true,
+            is_bought_date = CURRENT_DATE,
+            updated_date = NOW()
+        WHERE id = #{saleId}
+          AND is_bought = false
+    </update>
+
     <select id="existsByBarcode" parameterType="String" resultType="boolean">
         SELECT EXISTS
                        (SELECT 1 FROM sale WHERE barcode = #{barcode})

--- a/src/test/java/com/jinddung2/givemeticon/domain/sale/service/SaleServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/sale/service/SaleServiceTest.java
@@ -120,6 +120,27 @@ class SaleServiceTest {
     }
 
     @Test
+    @DisplayName("판매 상태 변경은 조건부 업데이트가 성공한 경우에만 성공한다.")
+    void markAsBoughtIfAvailable() {
+        int saleId = 1;
+        Mockito.when(saleMapper.updateBoughtStateIfNotBought(saleId)).thenReturn(1);
+
+        sut.markAsBoughtIfAvailable(saleId);
+
+        Mockito.verify(saleMapper).updateBoughtStateIfNotBought(saleId);
+    }
+
+    @Test
+    @DisplayName("조건부 업데이트가 실패하면 이미 판매된 상품으로 처리한다.")
+    void markAsBoughtIfAvailable_Fail_AlreadyBought() {
+        int saleId = 1;
+        Mockito.when(saleMapper.updateBoughtStateIfNotBought(saleId)).thenReturn(0);
+
+        Assertions.assertThrows(AlreadyBoughtSaleException.class,
+                () -> sut.markAsBoughtIfAvailable(saleId));
+    }
+
+    @Test
     @DisplayName("판매 상품 재고조회에 성공한다.")
     void get_Sales_By_ItemId_Success() {
         User seller = UserFixture.createUserFixture(now);

--- a/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeWriteFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/trade/facade/TradeWriteFacadeTest.java
@@ -24,7 +24,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -61,9 +60,7 @@ class TradeWriteFacadeTest {
 
         sut.transact(sale.getId(), buyer.getId());
 
-        assertThat(sale.isBought()).isTrue();
-
-        verify(saleService).update(sale);
+        verify(saleService).markAsBoughtIfAvailable(sale.getId());
         verify(tradeService).save(sale, item, buyer.getId());
         verify(producer).create(any(CreateNotificationRequestDto.class));
     }
@@ -76,9 +73,12 @@ class TradeWriteFacadeTest {
         Sale sale = SaleFixture.createBoughtSaleFixture(buyer, item);
 
         when(saleService.getSale(sale.getId())).thenReturn(sale);
+        doThrow(new AlreadyBoughtSaleException()).when(saleService).markAsBoughtIfAvailable(sale.getId());
 
         assertThatThrownBy(() -> sut.transact(sale.getId(), buyer.getId()))
                 .isInstanceOf(AlreadyBoughtSaleException.class);
+
+        verify(tradeService, never()).save(any(Sale.class), any(Item.class), anyInt());
     }
 
     @Test


### PR DESCRIPTION

- close #{118}

## 목표 및 요구사항

> 목표: 상품 중복 구매 문제 해결

* 해당 작업에 관한 요구사항에 대해 정리 합니다.

## 세부설명

### 문제
* 두 유저가 동시에 is_bought = false 읽음
* 둘 다 구매 진행 → 둘 다 성공
### 본질 (재정의)
상태 기반 판단 로직 → 검증과 변경이 분리된 구조