### PR TITLE
[fix] 쿠폰 중복 사용 동시성 문제 해결 (DB 원자성 기반 처리)

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/domain/Coupon.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/domain/Coupon.java
@@ -66,6 +66,11 @@ public class Coupon {
         validateExpiration(currentDate);
     }
 
+    public void validateRedeemRequest(int userId, LocalDate currentDate) {
+        validateUserOwnership(userId);
+        validateExpiration(currentDate);
+    }
+
     private void validateUserOwnership(int userId) {
         if (this.userId != userId) {
             throw new CouponUserMismatchException();

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/facade/RedeemCouponFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/facade/RedeemCouponFacade.java
@@ -26,18 +26,7 @@ public class RedeemCouponFacade {
         Coupon coupon = couponService.getCoupon(requestDto.couponNumber());
 
         LocalDate currentDate = LocalDate.now();
-        coupon.isValidate(userId, currentDate);
-        /*if (coupon.getUserId() != userId) {
-            throw new CouponUserMismatchException();
-        }
-
-        if (coupon.isUsed()) {
-            throw new AlreadyRedeemedCouponException();
-        }
-
-        if (currentDate.isAfter(coupon.getExpiredDate())) {
-            throw new ExpiredCouponException();
-        }*/
+        coupon.validateRedeemRequest(userId, currentDate);
 
         couponService.useCoupon(coupon);
         cashPointService.addPoint(user, coupon);

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponMapper.java
@@ -2,6 +2,7 @@ package com.jinddung2.givemeticon.domain.coupon.mapper;
 
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -10,6 +11,8 @@ public interface CouponMapper {
     int save(Coupon coupon);
 
     int merge(Coupon coupon);
+
+    int updateUsedIfUnused(@Param("id") int id);
 
     Optional<Coupon> getCouponById(int couponId);
 

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponService.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.coupon.service;
 import com.jinddung2.givemeticon.common.utils.CertificationGenerator;
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyRedeemedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCoupon;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponMapper;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +40,10 @@ public class CouponService {
     }
 
     public void useCoupon(Coupon coupon) {
-        coupon.useCoupon();
-        couponMapper.merge(coupon);
+        int updatedRows = couponMapper.updateUsedIfUnused(coupon.getId());
+        if (updatedRows != 1) {
+            throw new AlreadyRedeemedCouponException();
+        }
     }
 
     public Coupon getCoupon(String couponNumber) {

--- a/src/main/resources/mapper/CouponMapper.xml
+++ b/src/main/resources/mapper/CouponMapper.xml
@@ -41,6 +41,13 @@
         WHERE id = #{id};
     </update>
 
+    <update id="updateUsedIfUnused" parameterType="int">
+        UPDATE coupon
+        SET is_used = true
+        WHERE id = #{id}
+          AND is_used = false
+    </update>
+
 <!--    <select id="getCouponById">-->
 <!--        SELECT id,-->
 <!--               user_id,-->

--- a/src/test/java/com/jinddung2/givemeticon/domain/coupon/facade/RedeemCouponFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/coupon/facade/RedeemCouponFacadeTest.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.coupon.facade;
 import com.jinddung2.givemeticon.domain.coupon.controller.dto.ReDeemCouponRequestDto;
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyRedeemedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.service.CouponService;
 import com.jinddung2.givemeticon.domain.point.service.CashPointService;
 import com.jinddung2.givemeticon.domain.user.domain.User;
@@ -16,6 +17,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -56,5 +60,30 @@ class RedeemCouponFacadeTest {
         verify(couponService).getCoupon(requestDto.couponNumber());
         verify(couponService).useCoupon(testCoupon);
         verify(cashPointService).addPoint(testUser, testCoupon);
+    }
+
+    @Test
+    @DisplayName("이미 사용된 쿠폰이면 포인트를 지급하지 않는다.")
+    void redeem_coupon_fail_already_redeemed() {
+        int userId = 1;
+        User testUser = User.builder().id(userId).build();
+        Coupon testCoupon = Coupon.builder()
+                .userId(userId)
+                .name("testCoupon")
+                .couponNumber("COUPON123")
+                .couponType(CouponType.FREE_POINT)
+                .isUsed(false)
+                .expiredDate(LocalDate.now().plusDays(1))
+                .build();
+        ReDeemCouponRequestDto requestDto = new ReDeemCouponRequestDto("COUPON123");
+
+        when(userService.getUser(userId)).thenReturn(testUser);
+        when(couponService.getCoupon(requestDto.couponNumber())).thenReturn(testCoupon);
+        doThrow(new AlreadyRedeemedCouponException()).when(couponService).useCoupon(testCoupon);
+
+        assertThatThrownBy(() -> sut.redeemCoupon(userId, requestDto))
+                .isInstanceOf(AlreadyRedeemedCouponException.class);
+
+        verify(cashPointService, never()).addPoint(testUser, testCoupon);
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponServiceTest.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.coupon.service;
 import com.jinddung2.givemeticon.common.utils.CertificationGenerator;
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyRedeemedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCoupon;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponMapper;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,6 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,7 +52,7 @@ class CouponServiceTest {
     }
 
     @Test
-    @DisplayName("쿠폰을 사용하면 쿠폰사용상태가 true로 바뀌고 db에 merge 된다.")
+    @DisplayName("쿠폰을 사용하면 조건부 업데이트가 성공한다.")
     void use_coupon_success(){
         int userId = 1;
         Coupon coupon = Coupon.builder()
@@ -63,11 +63,29 @@ class CouponServiceTest {
                 .isUsed(false)
                 .expiredDate(LocalDate.now().plusDays(1))
                 .build();
+        when(couponMapper.updateUsedIfUnused(coupon.getId())).thenReturn(1);
 
         sut.useCoupon(coupon);
 
-        assertTrue(coupon.isUsed());
-        verify(couponMapper).merge(coupon);
+        verify(couponMapper).updateUsedIfUnused(coupon.getId());
+        verify(couponMapper, never()).merge(coupon);
+    }
+
+    @Test
+    @DisplayName("조건부 업데이트가 실패하면 이미 사용한 쿠폰으로 처리한다.")
+    void use_coupon_fail_already_redeemed() {
+        Coupon coupon = Coupon.builder()
+                .userId(1)
+                .name("testCoupon")
+                .couponNumber("COUPON123")
+                .couponType(CouponType.FREE_POINT)
+                .isUsed(false)
+                .expiredDate(LocalDate.now().plusDays(1))
+                .build();
+        when(couponMapper.updateUsedIfUnused(coupon.getId())).thenReturn(0);
+
+        assertThrows(AlreadyRedeemedCouponException.class,
+                () -> sut.useCoupon(coupon));
     }
 
     @Test


### PR DESCRIPTION
- close #{120}

## 목표 및 요구사항

> 목표:

* 쿠폰 중복 사용 동시성 문제 해결

## 세부설명

### 문제 정의
기존 쿠폰 사용 로직은 coupon.isUsed() 조회 후 포인트를 지급하는 구조였습니다.
이 방식은 동시 요청 환경에서 여러 요청이 동일한 상태를 읽고 모두 성공 처리되는 문제가 있었습니다.

### 문제 재정의
이 문제는 단순한 검증 로직의 문제가 아니라,
검증과 상태 변경이 분리된 구조로 인해 발생하는 정합성 문제였습니다.

### 해결 방식
애플리케이션 레벨 검증을 제거하고,
데이터베이스 조건부 업데이트 기반의 원자적 처리로 전환했습니다.

```sql
UPDATE coupon
SET is_used = true
WHERE id = ? AND is_used = false