### PR TITLE
[fix] 포인트 Lost Update 동시성 문제 해결 (DB 누적 연산 방식 적용)

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/domain/point/mapper/CashPointMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/point/mapper/CashPointMapper.java
@@ -2,6 +2,7 @@ package com.jinddung2.givemeticon.domain.point.mapper;
 
 import com.jinddung2.givemeticon.domain.point.domain.CashPoint;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.Optional;
 
@@ -9,7 +10,8 @@ import java.util.Optional;
 public interface CashPointMapper {
     int save(CashPoint cashPoint);
 
-    int merge(CashPoint cashPoint);
+    int incrementCashPoint(@Param("id") int id,
+                           @Param("amount") int amount);
 
     Optional<CashPoint> findById(int id);
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/point/service/CashPointService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/point/service/CashPointService.java
@@ -26,14 +26,22 @@ public class CashPointService {
         return cashPoint.getId();
     }
 
+    @Transactional
     public void addPoint(User user, Coupon coupon) {
-        CashPoint cashPoint = cashPointMapper.findById(user.getCashPointId())
-                .orElseThrow();
-        cashPoint.addPoint(coupon.getPrice());
-        cashPointMapper.merge(cashPoint);
+        validatePointAmount(coupon.getPrice());
+        int updatedRows = cashPointMapper.incrementCashPoint(user.getCashPointId(), coupon.getPrice());
+        if (updatedRows != 1) {
+            throw new NotFoundCashPoint();
+        }
     }
 
     public CashPoint getCashPoint(int cashPointId) {
         return cashPointMapper.findById(cashPointId).orElseThrow(NotFoundCashPoint::new);
+    }
+
+    private void validatePointAmount(int amount) {
+        if (amount < 0) {
+            throw new IllegalArgumentException("추가할 포인트는 양수여야 합니다.");
+        }
     }
 }

--- a/src/main/resources/mapper/CashPointMapper.xml
+++ b/src/main/resources/mapper/CashPointMapper.xml
@@ -13,9 +13,9 @@
                 NOW())
     </insert>
 
-    <update id="merge" parameterType="CashPoint">
+    <update id="incrementCashPoint">
         UPDATE cash_point
-        SET cash_point = #{cashPoint}
+        SET cash_point = cash_point + #{amount}
         WHERE id = #{id}
     </update>
 

--- a/src/test/java/com/jinddung2/givemeticon/domain/point/service/CashCashPointServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/point/service/CashCashPointServiceTest.java
@@ -1,8 +1,11 @@
 package com.jinddung2.givemeticon.domain.point.service;
 
+import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
+import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
 import com.jinddung2.givemeticon.domain.point.domain.CashPoint;
 import com.jinddung2.givemeticon.domain.point.exception.NotFoundCashPoint;
 import com.jinddung2.givemeticon.domain.point.mapper.CashPointMapper;
+import com.jinddung2.givemeticon.domain.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,6 +17,7 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -59,5 +63,50 @@ class CashCashPointServiceTest {
 
         assertThrows(NotFoundCashPoint.class,
                 () -> sut.getCashPoint(pointId));
+    }
+
+    @Test
+    @DisplayName("쿠폰 금액만큼 캐시포인트를 원자적으로 증가시킨다.")
+    void add_point_success() {
+        int cashPointId = 1;
+        int price = 500;
+        User user = User.builder()
+                .cashPointId(cashPointId)
+                .build();
+        Coupon coupon = Coupon.builder()
+                .userId(1)
+                .name("testCoupon")
+                .couponNumber("COUPON123")
+                .couponType(CouponType.FREE_POINT)
+                .price(price)
+                .build();
+        when(cashPointMapper.incrementCashPoint(cashPointId, price)).thenReturn(1);
+
+        sut.addPoint(user, coupon);
+
+        verify(cashPointMapper).incrementCashPoint(cashPointId, price);
+        verify(cashPointMapper, never()).findById(cashPointId);
+        verify(cashPointMapper, never()).merge(any(CashPoint.class));
+    }
+
+    @Test
+    @DisplayName("캐시포인트 증가 대상이 없으면 NotFoundCashPoint 예외를 발생시킨다.")
+    void add_point_fail_not_found_cash_point() {
+        int cashPointId = 1;
+        int price = 500;
+        User user = User.builder()
+                .cashPointId(cashPointId)
+                .build();
+        Coupon coupon = Coupon.builder()
+                .userId(1)
+                .name("testCoupon")
+                .couponNumber("COUPON123")
+                .couponType(CouponType.FREE_POINT)
+                .price(price)
+                .build();
+        when(cashPointMapper.incrementCashPoint(cashPointId, price)).thenReturn(0);
+
+        assertThrows(NotFoundCashPoint.class,
+                () -> sut.addPoint(user, coupon));
     }
 }


### PR DESCRIPTION

- close #122

## 목표 및 요구사항

> 목표: 포인트 적립 lost update 문제 해결

### 📌 문제 정의
* 기존 포인트 적립 로직은 현재 값을 조회한 뒤, 메모리에서 계산 후 다시 저장하는 방식이었습니다.
* 이 구조는 동시 요청 환경에서 여러 요청이 동일한 값을 기반으로 연산을 수행하여, 최종적으로 일부 요청의 결과가 덮어써지는 문제가 있었습니다.

### ⚠️ 문제 재정의
* 이 문제는 연산 책임이 애플리케이션 레벨에 있는 구조적 문제였습니다.

### 💡 해결 방식
* 연산 책임을 데이터베이스로 이동시켜, 원자적 누적 연산 방식으로 변경했습니다.