### PR TITLE
[Fix] Kafka 중복 소비 대응을 위한 멱등성 처리 도입

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/common/config/kafka/NotificationConsumerConfig.java
+++ b/src/main/java/com/jinddung2/givemeticon/common/config/kafka/NotificationConsumerConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 
 import java.util.HashMap;
@@ -25,6 +26,7 @@ public class NotificationConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, CreateNotificationRequestDto> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(notificationConsumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
 
         return factory;
     }
@@ -41,6 +43,7 @@ public class NotificationConsumerConfig {
         Map<String, Object> props = new HashMap<>();
         props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
         props.put(ConsumerConfig.GROUP_ID_CONFIG, "alarm");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         return props;
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/notification/consumer/NotificationConsumer.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/notification/consumer/NotificationConsumer.java
@@ -6,9 +6,10 @@ import com.jinddung2.givemeticon.domain.notification.mapper.NotificationMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -16,17 +17,22 @@ public class NotificationConsumer {
     private final NotificationMapper notificationMapper;
 
     @KafkaListener(topics = "alarm", groupId = "alarm", containerFactory = "notificationListenerContainerFactory")
+    @Transactional
     public void consume(ConsumerRecord<String, CreateNotificationRequestDto> record) {
-        try {
-            notificationMapper.save(new Notification(
-                    record.value().saleId(),
-                    record.value().sellerId(),
-                    record.value().message(),
-                    false
-            ));
-            log.info("consumed message={}", record.value());
-        } catch (KafkaException e) {
-            log.error("failed to create alarm:: msg={}", e.getMessage());
+        CreateNotificationRequestDto request = record.value();
+        int insertedRows = notificationMapper.saveIdempotently(new Notification(
+                request.eventId(),
+                request.saleId(),
+                request.sellerId(),
+                request.message(),
+                false
+        ));
+
+        if (insertedRows == 0) {
+            log.info("duplicated notification event ignored eventId={}", request.eventId());
+            return;
         }
+
+        log.info("consumed notification eventId={}, message={}", request.eventId(), request);
     }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/notification/domain/Notification.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/notification/domain/Notification.java
@@ -10,13 +10,15 @@ import java.time.LocalDateTime;
 public class Notification {
 
     private int id;
+    private String eventId;
     private int saleId;
     private int sellerId;
     private String message;
     private boolean isRead;
     private LocalDateTime createdDate;
 
-    public Notification(int saleId, int sellerId, String message, boolean isRead) {
+    public Notification(String eventId, int saleId, int sellerId, String message, boolean isRead) {
+        this.eventId = eventId;
         this.saleId = saleId;
         this.sellerId = sellerId;
         this.message = message;

--- a/src/main/java/com/jinddung2/givemeticon/domain/notification/domain/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/notification/domain/dto/CreateNotificationRequestDto.java
@@ -1,8 +1,33 @@
 package com.jinddung2.givemeticon.domain.notification.domain.dto;
 
-public record CreateNotificationRequestDto (
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public record CreateNotificationRequestDto(
+        String eventId,
         int saleId,
         int sellerId,
         String message
 ) {
+    public CreateNotificationRequestDto {
+        if (eventId == null || eventId.isBlank()) {
+            eventId = deriveEventId(saleId, sellerId, message);
+        }
+    }
+
+    public CreateNotificationRequestDto(int saleId, int sellerId, String message) {
+        this(null, saleId, sellerId, message);
+    }
+
+    private static String deriveEventId(int saleId, int sellerId, String message) {
+        String payload = saleId + "|" + sellerId + "|" + message;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(payload.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is not available", e);
+        }
+    }
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/notification/mapper/NotificationMapper.java
@@ -5,5 +5,5 @@ import org.apache.ibatis.annotations.Mapper;
 
 @Mapper
 public interface NotificationMapper {
-    int save(Notification notification);
+    int saveIdempotently(Notification notification);
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/notification/producer/NotificationProducer.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/notification/producer/NotificationProducer.java
@@ -17,7 +17,7 @@ public class NotificationProducer {
     }
 
     public void create(CreateNotificationRequestDto request) {
-        kafkaTemplate.send(TOPIC_NAME, request);
+        kafkaTemplate.send(TOPIC_NAME, request.eventId(), request);
         log.info("kafka producer message request={}", request);
     }
 }

--- a/src/main/resources/mapper/NotificationMapper.xml
+++ b/src/main/resources/mapper/NotificationMapper.xml
@@ -3,18 +3,21 @@
         "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 
 <mapper namespace="com.jinddung2.givemeticon.domain.notification.mapper.NotificationMapper">
-    <insert id="save" parameterType="Notification" useGeneratedKeys="true" keyProperty="id">
+    <insert id="saveIdempotently" parameterType="Notification" useGeneratedKeys="true" keyProperty="id">
         INSERT INTO notification (id,
+                                  event_id,
                                   sale_id,
                                   seller_id,
                                   message,
                                   is_read,
                                   created_date)
         VALUES (#{id},
+                #{eventId},
                 #{saleId},
                 #{sellerId},
                 #{message},
                 #{isRead},
                 NOW())
+        ON DUPLICATE KEY UPDATE event_id = event_id
     </insert>
 </mapper>

--- a/src/test/java/com/jinddung2/givemeticon/domain/notification/consumer/NotificationConsumerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/notification/consumer/NotificationConsumerTest.java
@@ -4,19 +4,19 @@ import com.jinddung2.givemeticon.domain.notification.domain.Notification;
 import com.jinddung2.givemeticon.domain.notification.domain.dto.CreateNotificationRequestDto;
 import com.jinddung2.givemeticon.domain.notification.mapper.NotificationMapper;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.HashSet;
+import java.util.Set;
+
 @ExtendWith(MockitoExtension.class)
 class NotificationConsumerTest {
-
-    @InjectMocks
-    NotificationConsumer sut;
 
     @Mock
     NotificationMapper notificationMapper;
@@ -24,15 +24,73 @@ class NotificationConsumerTest {
     @Test
     @DisplayName("알람 요청을 consume 해서 DB에 저장한다.")
     void consume() {
-        int saleId = 1, sellerId = 2, notificationId= 3;
+        NotificationConsumer sut = new NotificationConsumer(notificationMapper);
+        int saleId = 1, sellerId = 2, notificationId = 3;
         CreateNotificationRequestDto requestFakeDto = new CreateNotificationRequestDto(saleId, sellerId, "fakeMessage");
         ConsumerRecord<String, CreateNotificationRequestDto> record =
                 new ConsumerRecord<>("fakeTopic", 0, 0, "fakeKey", requestFakeDto);
 
-        Mockito.when(notificationMapper.save(Mockito.any(Notification.class))).thenReturn(notificationId);
+        Mockito.when(notificationMapper.saveIdempotently(Mockito.any(Notification.class))).thenReturn(notificationId);
 
         sut.consume(record);
 
-        Mockito.verify(notificationMapper).save(Mockito.any(Notification.class));
+        Mockito.verify(notificationMapper).saveIdempotently(Mockito.argThat(notification ->
+                notification.getEventId().equals(requestFakeDto.eventId())
+                        && notification.getSaleId() == saleId
+                        && notification.getSellerId() == sellerId
+                        && notification.getMessage().equals("fakeMessage")
+                        && !notification.isRead()
+        ));
+    }
+
+    @Test
+    @DisplayName("동일한 eventId가 재전달되어도 알람은 한 번만 저장된다.")
+    void consume_duplicate_delivery_is_idempotent() {
+        InMemoryIdempotentNotificationMapper mapper = new InMemoryIdempotentNotificationMapper();
+        NotificationConsumer sut = new NotificationConsumer(mapper);
+        CreateNotificationRequestDto request = new CreateNotificationRequestDto(
+                "event-1", 1, 2, "fakeMessage"
+        );
+        ConsumerRecord<String, CreateNotificationRequestDto> record =
+                new ConsumerRecord<>("fakeTopic", 0, 0, "event-1", request);
+
+        sut.consume(record);
+        sut.consume(record);
+
+        Assertions.assertThat(mapper.insertedCount()).isEqualTo(1);
+        Assertions.assertThat(mapper.duplicateCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("eventId가 없으면 payload 기반으로 같은 idempotency key를 생성한다.")
+    void createNotificationRequestDto_derives_event_id_from_payload() {
+        CreateNotificationRequestDto first = new CreateNotificationRequestDto(1, 2, "fakeMessage");
+        CreateNotificationRequestDto duplicate = new CreateNotificationRequestDto(1, 2, "fakeMessage");
+        CreateNotificationRequestDto different = new CreateNotificationRequestDto(1, 2, "otherMessage");
+
+        Assertions.assertThat(first.eventId()).isEqualTo(duplicate.eventId());
+        Assertions.assertThat(first.eventId()).isNotEqualTo(different.eventId());
+    }
+
+    private static class InMemoryIdempotentNotificationMapper implements NotificationMapper {
+        private final Set<String> eventIds = new HashSet<>();
+        private int duplicateCount;
+
+        @Override
+        public int saveIdempotently(Notification notification) {
+            if (eventIds.add(notification.getEventId())) {
+                return 1;
+            }
+            duplicateCount++;
+            return 0;
+        }
+
+        int insertedCount() {
+            return eventIds.size();
+        }
+
+        int duplicateCount() {
+            return duplicateCount;
+        }
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/notification/producer/NotificationProducerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/notification/producer/NotificationProducerTest.java
@@ -28,6 +28,6 @@ class NotificationProducerTest {
 
         sut.create(fakeDto);
 
-        Mockito.verify(kafkaTemplate).send(Mockito.eq("alarm"), Mockito.eq(fakeDto));
+        Mockito.verify(kafkaTemplate).send(Mockito.eq("alarm"), Mockito.eq(fakeDto.eventId()), Mockito.eq(fakeDto));
     }
 }


### PR DESCRIPTION
- close #126 

## 목표 및 요구사항

> 목표:

- 중복 소비에도 단일 처리 보장
- 재시도/장애 복구 시 데이터 정합성 유지
- 이벤트 기반 아키텍처의 신뢰성 향상

## 세부설명

### 문제 정의
Kafka의 at-least-once 전달 특성으로 동일 이벤트가 재전달될 수 있으나,
기존 소비자는 매번 insert를 수행하여 중복 데이터가 생성되었습니다.

### 해결 방식
- eventId(idempotency key) 도입
- DB UNIQUE 제약으로 단일성 보장
- idempotent insert (ON CONFLICT DO NOTHING / INSERT IGNORE) 적용
- 중복 이벤트는 no-op 처리
- DB 반영 이후에만 ack 하여 재시도 안전성 확보

### 변경 사항
- notification.event_id UNIQUE 추가
- repository에 idempotent insert 메서드 추가
- consumer 로직에서 eventId 기반 처리로 전환
- 중복 전달 테스트 추가