### PR TITLE
Feature/#116 separate meta table

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/domain/favorite/mapper/ItemFavoriteMetaMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/favorite/mapper/ItemFavoriteMetaMapper.java
@@ -8,4 +8,8 @@ public interface ItemFavoriteMetaMapper {
 
     void save(@Param("itemId") int itemId);
 
+    void increaseViewCount(@Param("itemId") int itemId);
+
+    void increaseLikeCount(@Param("itemId") int itemId);
+
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/favorite/service/ItemFavoriteService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/favorite/service/ItemFavoriteService.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.favorite.service;
 import com.jinddung2.givemeticon.domain.favorite.domain.ItemFavorite;
 import com.jinddung2.givemeticon.domain.favorite.exception.AlreadyPushItemFavorite;
 import com.jinddung2.givemeticon.domain.favorite.exception.NotPushItemFavorite;
+import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
 import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class ItemFavoriteService {
     private final ItemFavoriteMapper itemFavoriteMapper;
+    private final ItemFavoriteMetaMapper itemFavoriteMetaMapper;
 
     public void insertFavorite(int userId, int itemId) {
         if (getItemFavoriteByUserIDAndItemId(userId, itemId).isPresent()) {
@@ -27,6 +29,7 @@ public class ItemFavoriteService {
                 .build();
 
         itemFavoriteMapper.save(itemFavorite);
+        itemFavoriteMetaMapper.increaseLikeCount(itemId);
     }
 
     public void cancelItemFavorite(int userId, int itemId) {

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/controller/ItemController.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/controller/ItemController.java
@@ -1,11 +1,14 @@
 package com.jinddung2.givemeticon.domain.item.controller;
 
 import com.jinddung2.givemeticon.domain.item.controller.dto.ItemDto;
+import com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto;
 import com.jinddung2.givemeticon.domain.item.controller.dto.request.ItemCreateRequest;
 import com.jinddung2.givemeticon.domain.item.facade.ItemWriteFacade;
 import com.jinddung2.givemeticon.domain.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 import static com.jinddung2.givemeticon.domain.user.constants.SessionConstants.LOGIN_USER;
 
@@ -21,6 +24,12 @@ public class ItemController {
     public ItemDto createItem(@PathVariable("brandId") int brandId,
                            @RequestBody ItemCreateRequest request) {
         return itemWriteFacade.createItem(brandId, request);
+    }
+
+    @GetMapping("/popular")
+    public List<PopularItemDto> getPopularItems(@RequestParam(defaultValue = "LIKE") String sort,
+                                                @RequestParam(defaultValue = "50") int limit) {
+        return itemService.getPopularItems(sort, limit);
     }
 
     @GetMapping("/{itemId}")

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/mapper/ItemMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/mapper/ItemMapper.java
@@ -1,8 +1,11 @@
 package com.jinddung2.givemeticon.domain.item.mapper;
 
+import com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 @Mapper
@@ -11,5 +14,9 @@ public interface ItemMapper {
     int saveOrUpdate(Item item);
 
     Optional<Item> findById(int itemId);
+
+    List<PopularItemDto> findPopularItemsOrderByLikeCount(@Param("limit") int limit);
+
+    List<PopularItemDto> findPopularItemsOrderByViewCount(@Param("limit") int limit);
 
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
@@ -2,6 +2,7 @@ package com.jinddung2.givemeticon.domain.item.service;
 
 import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
 import com.jinddung2.givemeticon.domain.item.controller.dto.ItemDto;
+import com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.NotFoundItemException;
 import com.jinddung2.givemeticon.domain.item.mapper.ItemMapper;
@@ -9,11 +10,15 @@ import com.jinddung2.givemeticon.domain.item.mapper.ItemViewMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class ItemService {
+
+    private static final int DEFAULT_POPULAR_ITEM_LIMIT = 50;
+    private static final int MAX_POPULAR_ITEM_LIMIT = 100;
 
     private final ItemMapper itemMapper;
     private final ItemViewMapper itemViewMapper;
@@ -36,10 +41,27 @@ public class ItemService {
         return ItemDto.of(item);
     }
 
+    public List<PopularItemDto> getPopularItems(String sort, int limit) {
+        int normalizedLimit = normalizeLimit(limit);
+        if ("VIEW".equalsIgnoreCase(sort)) {
+            return itemMapper.findPopularItemsOrderByViewCount(normalizedLimit);
+        }
+
+        return itemMapper.findPopularItemsOrderByLikeCount(normalizedLimit);
+    }
+
     public boolean isExists(int itemId) {
         Optional<Item> item = itemMapper.findById(itemId);
 
         return item.isPresent();
+    }
+
+    private int normalizeLimit(int limit) {
+        if (limit <= 0) {
+            return DEFAULT_POPULAR_ITEM_LIMIT;
+        }
+
+        return Math.min(limit, MAX_POPULAR_ITEM_LIMIT);
     }
 
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/item/service/ItemService.java
@@ -1,5 +1,6 @@
 package com.jinddung2.givemeticon.domain.item.service;
 
+import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
 import com.jinddung2.givemeticon.domain.item.controller.dto.ItemDto;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.NotFoundItemException;
@@ -16,6 +17,7 @@ public class ItemService {
 
     private final ItemMapper itemMapper;
     private final ItemViewMapper itemViewMapper;
+    private final ItemFavoriteMetaMapper itemFavoriteMetaMapper;
 
     public Item saveOrUpdate(Item item) {
         int id = itemMapper.saveOrUpdate(item);
@@ -29,8 +31,8 @@ public class ItemService {
     public ItemDto getItemAndIncreaseViewCount(int itemId, int userId) {
         Item item = getItem(itemId);
         itemViewMapper.save(itemId, userId);
+        itemFavoriteMetaMapper.increaseViewCount(itemId);
 
-        itemMapper.saveOrUpdate(item);
         return ItemDto.of(item);
     }
 

--- a/src/main/resources/mapper/ItemFavoriteMetaMapper.xml
+++ b/src/main/resources/mapper/ItemFavoriteMetaMapper.xml
@@ -13,4 +13,16 @@
                 0,
                 0)
     </insert>
+
+    <update id="increaseViewCount">
+        UPDATE item_favorite_meta
+        SET view_count = view_count + 1
+        WHERE item_id = #{itemId}
+    </update>
+
+    <update id="increaseLikeCount">
+        UPDATE item_favorite_meta
+        SET like_count = like_count + 1
+        WHERE item_id = #{itemId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/ItemMapper.xml
+++ b/src/main/resources/mapper/ItemMapper.xml
@@ -28,4 +28,34 @@
         WHERE id = #{itemId}
     </select>
 
+    <select id="findPopularItemsOrderByLikeCount"
+            resultType="com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto">
+        SELECT i.id,
+               i.brand_id,
+               i.name,
+               i.price,
+               m.like_count,
+               m.view_count
+        FROM item_favorite_meta m
+        JOIN item i
+          ON i.id = m.item_id
+        ORDER BY m.like_count DESC, m.item_id DESC
+        LIMIT #{limit}
+    </select>
+
+    <select id="findPopularItemsOrderByViewCount"
+            resultType="com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto">
+        SELECT i.id,
+               i.brand_id,
+               i.name,
+               i.price,
+               m.like_count,
+               m.view_count
+        FROM item_favorite_meta m
+        JOIN item i
+          ON i.id = m.item_id
+        ORDER BY m.view_count DESC, m.item_id DESC
+        LIMIT #{limit}
+    </select>
+
 </mapper>

--- a/src/test/java/com/jinddung2/givemeticon/domain/favorite/service/ItemFavoriteServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/favorite/service/ItemFavoriteServiceTest.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.favorite.service;
 import com.jinddung2.givemeticon.domain.favorite.domain.ItemFavorite;
 import com.jinddung2.givemeticon.domain.favorite.exception.AlreadyPushItemFavorite;
 import com.jinddung2.givemeticon.domain.favorite.exception.NotPushItemFavorite;
+import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
 import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMapper;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.user.domain.User;
@@ -23,6 +24,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +37,9 @@ class ItemFavoriteServiceTest {
 
     @Mock
     ItemFavoriteMapper itemFavoriteMapper;
+
+    @Mock
+    ItemFavoriteMetaMapper itemFavoriteMetaMapper;
 
     LocalDateTime now = LocalDateTime.now();
 
@@ -50,6 +57,8 @@ class ItemFavoriteServiceTest {
         assertThat(itemFavorite.getItemId()).isEqualTo(item.getId());
         assertThat(itemFavorite.getUserId()).isEqualTo(user.getId());
         assertThat(itemFavorite.isFavorite()).isTrue();
+        verify(itemFavoriteMapper).save(any(ItemFavorite.class));
+        verify(itemFavoriteMetaMapper).increaseLikeCount(item.getId());
     }
 
     @Test
@@ -63,6 +72,9 @@ class ItemFavoriteServiceTest {
 
         Assertions.assertThrows(AlreadyPushItemFavorite.class,
                 () -> sut.insertFavorite(user.getId(), item.getId()));
+
+        verify(itemFavoriteMapper, never()).save(any(ItemFavorite.class));
+        verify(itemFavoriteMetaMapper, never()).increaseLikeCount(item.getId());
     }
 
     @Test

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/controller/ItemControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jinddung2.givemeticon.BasicControllerTest;
 import com.jinddung2.givemeticon.domain.brand.domain.Brand;
 import com.jinddung2.givemeticon.domain.item.controller.dto.ItemDto;
+import com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto;
 import com.jinddung2.givemeticon.domain.item.controller.dto.request.ItemCreateRequest;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.ItemErrorCode;
@@ -21,6 +22,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
 
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -87,6 +90,36 @@ class ItemControllerTest extends BasicControllerTest {
                 .andExpect(jsonPath("$.data.price").value(response.getPrice()));
 
         Mockito.verify(itemService).getItemAndIncreaseViewCount(item.getId(), userId);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 목록 조회에 성공한다.")
+    void getPopularItems_Success() throws Exception {
+        PopularItemDto response = new PopularItemDto();
+        response.setId(1);
+        response.setBrandId(2);
+        response.setName("popular item");
+        response.setPrice(1000);
+        response.setLikeCount(10);
+        response.setViewCount(20);
+
+        when(itemService.getPopularItems("LIKE", 50)).thenReturn(List.of(response));
+
+        mockMvc.perform(MockMvcRequestBuilders
+                        .get("/api/v1/items/popular")
+                        .param("sort", "LIKE")
+                        .param("limit", "50")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().is2xxSuccessful())
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data[0].id").value(response.getId()))
+                .andExpect(jsonPath("$.data[0].brandId").value(response.getBrandId()))
+                .andExpect(jsonPath("$.data[0].name").value(response.getName()))
+                .andExpect(jsonPath("$.data[0].price").value(response.getPrice()))
+                .andExpect(jsonPath("$.data[0].likeCount").value(response.getLikeCount()))
+                .andExpect(jsonPath("$.data[0].viewCount").value(response.getViewCount()));
+
+        Mockito.verify(itemService).getPopularItems("LIKE", 50);
     }
 
     @Test

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
@@ -1,8 +1,10 @@
 package com.jinddung2.givemeticon.domain.item.service;
 
+import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.NotFoundItemException;
 import com.jinddung2.givemeticon.domain.item.mapper.ItemMapper;
+import com.jinddung2.givemeticon.domain.item.mapper.ItemViewMapper;
 import com.jinddung2.givemeticon.fixture.ItemFixture;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +29,12 @@ class ItemServiceTest {
 
     @Mock
     ItemMapper itemMapper;
+
+    @Mock
+    ItemViewMapper itemViewMapper;
+
+    @Mock
+    ItemFavoriteMetaMapper itemFavoriteMetaMapper;
 
     @Test
     @DisplayName("전시용 아이템 저장에 성공한다.")
@@ -57,5 +67,19 @@ class ItemServiceTest {
 
         Assertions.assertThrows(NotFoundItemException.class,
                 () -> sut.getItem(item.getId()));
+    }
+
+    @Test
+    @DisplayName("아이템 상세 조회 시 item_favorite_meta 조회수를 증가시킨다.")
+    void getItemAndIncreaseViewCount_Increases_Meta_View_Count() {
+        int userId = 1;
+        Item item = ItemFixture.createItemFixture();
+        when(itemMapper.findById(item.getId())).thenReturn(Optional.of(item));
+
+        sut.getItemAndIncreaseViewCount(item.getId(), userId);
+
+        verify(itemViewMapper).save(item.getId(), userId);
+        verify(itemFavoriteMetaMapper).increaseViewCount(item.getId());
+        verify(itemMapper, never()).saveOrUpdate(item);
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/item/service/ItemServiceTest.java
@@ -1,6 +1,7 @@
 package com.jinddung2.givemeticon.domain.item.service;
 
 import com.jinddung2.givemeticon.domain.favorite.mapper.ItemFavoriteMetaMapper;
+import com.jinddung2.givemeticon.domain.item.controller.dto.PopularItemDto;
 import com.jinddung2.givemeticon.domain.item.domain.Item;
 import com.jinddung2.givemeticon.domain.item.exception.NotFoundItemException;
 import com.jinddung2.givemeticon.domain.item.mapper.ItemMapper;
@@ -14,6 +15,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,5 +83,56 @@ class ItemServiceTest {
         verify(itemViewMapper).save(item.getId(), userId);
         verify(itemFavoriteMetaMapper).increaseViewCount(item.getId());
         verify(itemMapper, never()).saveOrUpdate(item);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 LIKE 정렬은 like_count 기준 mapper를 호출한다.")
+    void getPopularItems_Sort_Like() {
+        List<PopularItemDto> expected = List.of(new PopularItemDto());
+        when(itemMapper.findPopularItemsOrderByLikeCount(50)).thenReturn(expected);
+
+        List<PopularItemDto> result = sut.getPopularItems("LIKE", 50);
+
+        assertThat(result).isEqualTo(expected);
+        verify(itemMapper).findPopularItemsOrderByLikeCount(50);
+        verify(itemMapper, never()).findPopularItemsOrderByViewCount(50);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 VIEW 정렬은 view_count 기준 mapper를 호출한다.")
+    void getPopularItems_Sort_View() {
+        List<PopularItemDto> expected = List.of(new PopularItemDto());
+        when(itemMapper.findPopularItemsOrderByViewCount(50)).thenReturn(expected);
+
+        List<PopularItemDto> result = sut.getPopularItems("VIEW", 50);
+
+        assertThat(result).isEqualTo(expected);
+        verify(itemMapper).findPopularItemsOrderByViewCount(50);
+        verify(itemMapper, never()).findPopularItemsOrderByLikeCount(50);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 limit이 최대값보다 크면 100으로 제한한다.")
+    void getPopularItems_Limit_Max() {
+        sut.getPopularItems("LIKE", 1000);
+
+        verify(itemMapper).findPopularItemsOrderByLikeCount(100);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 limit이 유효하지 않으면 기본값 50을 사용한다.")
+    void getPopularItems_Limit_Default() {
+        sut.getPopularItems("LIKE", 0);
+
+        verify(itemMapper).findPopularItemsOrderByLikeCount(50);
+    }
+
+    @Test
+    @DisplayName("인기 아이템 sort가 잘못되면 LIKE 정렬을 기본으로 사용한다.")
+    void getPopularItems_Invalid_Sort_Default_Like() {
+        sut.getPopularItems("INVALID", 20);
+
+        verify(itemMapper).findPopularItemsOrderByLikeCount(20);
+        verify(itemMapper, never()).findPopularItemsOrderByViewCount(20);
     }
 }


### PR DESCRIPTION

- close #116

## 목표 및 요구사항

> 목표: 데이터 증가에 따른 조회 성능 병목을 줄이기 위한 read model 기반 조회 구조 적용

## 작업 개요

좋아요순 조회를 GROUP BY 기반 실시간 집계 방식 대신 item_favorite_meta 기반 사전 집계 방식으로 조회할 수 있도록 인기 item 조회 API를 추가했습니다.

## 배경

기존 GROUP BY 기반 인기순 조회는 조회 시점마다:

- item_favorite 조인
- COUNT 집계
- GROUP BY
- temporary table 생성
- ORDER BY 정렬

을 수행해야 했습니다.

EXPLAIN ANALYZE 측정 결과:

| Dataset | GROUP BY like sort | meta like sort |
|---|---:|---:|
| small | 26ms | 5ms |
| medium | 226ms | 19ms |
| large | 4688ms | 145ms |

특히 large 데이터셋에서는 약 1,000,000 favorite row 기반 aggregation이 발생하며 temporary table과 정렬 비용이 급격히 증가했습니다.

반면 item_favorite_meta 기반 조회는 미리 계산된 like_count, view_count를 사용하여 조회 시 aggregation 비용을 제거할 수 있었습니다.

---

### API 추가

```http
GET /api/v1/items/popular?sort=LIKE&limit=50
GET /api/v1/items/popular?sort=VIEW&limit=50