### PR TITLE
[fix] 선착순 쿠폰 발급 정합성 강화

### DIFF
--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/exception/AlreadyIssuedCouponException.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/exception/AlreadyIssuedCouponException.java
@@ -1,0 +1,7 @@
+package com.jinddung2.givemeticon.domain.coupon.exception;
+
+public class AlreadyIssuedCouponException extends CouponException {
+    public AlreadyIssuedCouponException() {
+        super(CouponErrorCode.COUPON_ALREADY_ISSUED);
+    }
+}

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/facade/CreateCouponFacade.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/facade/CreateCouponFacade.java
@@ -2,7 +2,6 @@ package com.jinddung2.givemeticon.domain.coupon.facade;
 
 import com.jinddung2.givemeticon.common.annotation.DistributedLock;
 import com.jinddung2.givemeticon.domain.coupon.controller.dto.CreateCouponRequestDto;
-import com.jinddung2.givemeticon.domain.coupon.domain.CouponStock;
 import com.jinddung2.givemeticon.domain.coupon.service.CouponService;
 import com.jinddung2.givemeticon.domain.coupon.service.CouponStockService;
 import lombok.RequiredArgsConstructor;
@@ -27,9 +26,7 @@ public class CreateCouponFacade {
             boolean isProcessed = couponStockService.processCouponRequest(userId);
             if (isProcessed) {
                 // 3. 재고 차감 및 쿠폰 발급
-                CouponStock stock = couponStockService.getStock(requestDto.stockId());
-
-                couponStockService.decreaseStock(stock);
+                couponStockService.decreaseStock(requestDto.stockId());
                 couponService.createCoupon(
                         userId, requestDto.stockId(), requestDto.couponName(), requestDto.couponType(), requestDto.price()
                 );
@@ -45,4 +42,3 @@ public class CreateCouponFacade {
         }
     }
 }
-

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponMapper.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface CouponMapper {
     int save(Coupon coupon);
 
+    int saveIfNotIssued(Coupon coupon);
+
     int merge(Coupon coupon);
 
     int updateUsedIfUnused(@Param("id") int id);

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponStockMapper.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/mapper/CouponStockMapper.java
@@ -11,8 +11,7 @@ import java.util.Optional;
 public interface CouponStockMapper {
     Optional<CouponStock> findById(int id);
 
-    void decreaseStock(@Param("id") int id,
-                       @Param("remain") int remain);
+    int decreaseStockIfEnough(@Param("id") int id);
 
     List<CouponStock> findActiveCouponStocks();
 }

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponService.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.coupon.service;
 import com.jinddung2.givemeticon.common.utils.CertificationGenerator;
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyIssuedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyRedeemedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCoupon;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponMapper;
@@ -36,7 +37,10 @@ public class CouponService {
 
         coupon.validatePrice(price);
         coupon.validateExpiredDate();
-        couponMapper.save(coupon);
+        int insertedRows = couponMapper.saveIfNotIssued(coupon);
+        if (insertedRows != 1) {
+            throw new AlreadyIssuedCouponException();
+        }
     }
 
     public void useCoupon(Coupon coupon) {

--- a/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponStockService.java
+++ b/src/main/java/com/jinddung2/givemeticon/domain/coupon/service/CouponStockService.java
@@ -2,8 +2,10 @@ package com.jinddung2.givemeticon.domain.coupon.service;
 
 import com.jinddung2.givemeticon.common.exception.GiveMeTiConException;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponStock;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyIssuedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.CouponErrorCode;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCouponStock;
+import com.jinddung2.givemeticon.domain.coupon.exception.NotEnoughCouponStockException;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponStockMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,7 +37,7 @@ public class CouponStockService {
         if (isIssued != null && isIssued) {
             log.warn("User {} - Error: {}, Message: {}", userId, CouponErrorCode.COUPON_ALREADY_ISSUED.name(),
                     CouponErrorCode.COUPON_ALREADY_ISSUED.getErrorDetail());
-            throw new GiveMeTiConException(CouponErrorCode.COUPON_ALREADY_ISSUED);
+            throw new AlreadyIssuedCouponException();
         }
 
         long timestamp = System.currentTimeMillis();
@@ -67,9 +69,11 @@ public class CouponStockService {
     }
 
     @Transactional
-    public void decreaseStock(CouponStock stock) {
-        stock.decrease();
-        couponStockMapper.decreaseStock(stock.getId(), stock.getRemain());
+    public void decreaseStock(int stockId) {
+        int updatedRows = couponStockMapper.decreaseStockIfEnough(stockId);
+        if (updatedRows != 1) {
+            throw new NotEnoughCouponStockException();
+        }
     }
 
     public List<CouponStock> getActiveCouponStocks() {

--- a/src/main/resources/mapper/CouponMapper.xml
+++ b/src/main/resources/mapper/CouponMapper.xml
@@ -27,6 +27,27 @@
                 #{expiredDate})
     </insert>
 
+    <insert id="saveIfNotIssued" parameterType="Coupon" useGeneratedKeys="true" keyProperty="id">
+        INSERT IGNORE INTO coupon (user_id,
+                                   stock_id,
+                                   name,
+                                   coupon_type,
+                                   coupon_number,
+                                   price,
+                                   is_used,
+                                   created_date,
+                                   expired_date)
+        VALUES (#{userId},
+                #{stockId},
+                #{name},
+                #{couponType},
+                #{couponNumber},
+                #{price},
+                #{isUsed},
+                #{createdDate},
+                #{expiredDate})
+    </insert>
+
     <update id="merge" parameterType="Coupon">
         UPDATE coupon
         SET user_id       = #{userId},

--- a/src/main/resources/mapper/CouponStockMapper.xml
+++ b/src/main/resources/mapper/CouponStockMapper.xml
@@ -21,9 +21,10 @@
         FROM coupon_stock
     </select>
 
-    <update id="decreaseStock" parameterType="int">
+    <update id="decreaseStockIfEnough" parameterType="int">
         UPDATE coupon_stock
-        SET remain = #{remain}
+        SET remain = remain - 1
         WHERE id = #{id}
+          AND remain > 0
     </update>
 </mapper>

--- a/src/test/java/com/jinddung2/givemeticon/common/aop/DistributedLockAopTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/common/aop/DistributedLockAopTest.java
@@ -1,0 +1,73 @@
+package com.jinddung2.givemeticon.common.aop;
+
+import com.jinddung2.givemeticon.common.annotation.DistributedLock;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class DistributedLockAopTest {
+
+    private final RedissonClient redissonClient = mock(RedissonClient.class);
+    private final AopForTransaction aopForTransaction = mock(AopForTransaction.class);
+    private final RLock rLock = mock(RLock.class);
+    private final DistributedLockAop sut = new DistributedLockAop(redissonClient, aopForTransaction);
+
+    @Test
+    @DisplayName("락 획득 실패 시 성공으로 처리하지 않고 unlock도 호출하지 않는다.")
+    void lock_Fail_Does_Not_Proceed_Or_Unlock() throws Throwable {
+        ProceedingJoinPoint joinPoint = joinPoint();
+        when(redissonClient.getLock("LOCK:1")).thenReturn(rLock);
+        when(rLock.tryLock(5L, 3L, TimeUnit.SECONDS)).thenReturn(false);
+
+        assertThatThrownBy(() -> sut.lock(joinPoint))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to acquire distributed lock");
+
+        verify(aopForTransaction, never()).proceed(joinPoint);
+        verify(rLock, never()).unlock();
+    }
+
+    @Test
+    @DisplayName("락을 현재 스레드가 보유한 경우에만 작업 후 unlock 한다.")
+    void lock_Success_Unlocks_When_Current_Thread_Holds_Lock() throws Throwable {
+        ProceedingJoinPoint joinPoint = joinPoint();
+        when(redissonClient.getLock("LOCK:1")).thenReturn(rLock);
+        when(rLock.tryLock(5L, 3L, TimeUnit.SECONDS)).thenReturn(true);
+        when(rLock.isHeldByCurrentThread()).thenReturn(true);
+
+        sut.lock(joinPoint);
+
+        verify(aopForTransaction).proceed(joinPoint);
+        verify(rLock).unlock();
+    }
+
+    private ProceedingJoinPoint joinPoint() throws NoSuchMethodException {
+        Method method = LockTarget.class.getMethod("execute", int.class);
+        MethodSignature signature = mock(MethodSignature.class);
+        when(signature.getMethod()).thenReturn(method);
+        when(signature.getParameterNames()).thenReturn(new String[]{"stockId"});
+
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1});
+        return joinPoint;
+    }
+
+    private static class LockTarget {
+        @DistributedLock(key = "#stockId")
+        public void execute(int stockId) {
+        }
+    }
+}

--- a/src/test/java/com/jinddung2/givemeticon/domain/coupon/facade/CreateCouponFacadeTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/coupon/facade/CreateCouponFacadeTest.java
@@ -1,8 +1,8 @@
 package com.jinddung2.givemeticon.domain.coupon.facade;
 
 import com.jinddung2.givemeticon.domain.coupon.controller.dto.CreateCouponRequestDto;
-import com.jinddung2.givemeticon.domain.coupon.domain.CouponStock;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.NotEnoughCouponStockException;
 import com.jinddung2.givemeticon.domain.coupon.service.CouponService;
 import com.jinddung2.givemeticon.domain.coupon.service.CouponStockService;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +14,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -38,13 +40,9 @@ class CreateCouponFacadeTest {
     int total = 100;
     long waitTime = 5L;
     long releaseTime = 3L;
-    CouponStock mockStock;
-    CouponStock zeroStock;
 
     @BeforeEach
     void setUp() {
-        mockStock = CouponStock.of(total);
-        zeroStock = CouponStock.of(0);
         createCouponRequestDto = new CreateCouponRequestDto(stockId, couponName, CouponType.FREE_POINT, price);
     }
 
@@ -54,12 +52,7 @@ class CreateCouponFacadeTest {
 
         Mockito.doNothing().when(couponStockService).enqueueCouponRequest(userId);
         Mockito.when(couponStockService.processCouponRequest(userId)).thenReturn(true);
-        Mockito.when(couponStockService.getStock(stockId)).thenReturn(mockStock);
-
-        Mockito.doAnswer(invocation -> {
-            mockStock.decrease();
-            return null;
-        }).when(couponStockService).decreaseStock(mockStock);
+        Mockito.doNothing().when(couponStockService).decreaseStock(stockId);
 
         Mockito.doNothing().when(couponService).createCoupon(
                 userId,
@@ -72,7 +65,7 @@ class CreateCouponFacadeTest {
 
         verify(couponStockService).enqueueCouponRequest(userId);
         verify(couponStockService).processCouponRequest(userId);
-        verify(couponStockService).decreaseStock(mockStock);
+        verify(couponStockService).decreaseStock(stockId);
         verify(couponService).createCoupon(
                 userId,
                 createCouponRequestDto.stockId(),
@@ -80,6 +73,27 @@ class CreateCouponFacadeTest {
                 createCouponRequestDto.couponType(),
                 createCouponRequestDto.price());
         verify(couponStockService).markAsIssued(userId);
+        verify(couponStockService).removeCouponRequest(userId);
+    }
+
+    @Test
+    @DisplayName("쿠폰 재고가 부족하면 쿠폰을 생성하지 않는다.")
+    void create_Coupon_Fail_Not_Enough_Stock() {
+        Mockito.doNothing().when(couponStockService).enqueueCouponRequest(userId);
+        Mockito.when(couponStockService.processCouponRequest(userId)).thenReturn(true);
+        Mockito.doThrow(new NotEnoughCouponStockException()).when(couponStockService).decreaseStock(stockId);
+
+        assertThrows(NotEnoughCouponStockException.class,
+                () -> createCouponFacade.createCouponAndDecreaseStock(userId, createCouponRequestDto));
+
+        verify(couponStockService).decreaseStock(stockId);
+        verify(couponService, never()).createCoupon(
+                userId,
+                createCouponRequestDto.stockId(),
+                createCouponRequestDto.couponName(),
+                createCouponRequestDto.couponType(),
+                createCouponRequestDto.price());
+        verify(couponStockService, never()).markAsIssued(userId);
         verify(couponStockService).removeCouponRequest(userId);
     }
 }

--- a/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponServiceTest.java
@@ -3,6 +3,7 @@ package com.jinddung2.givemeticon.domain.coupon.service;
 import com.jinddung2.givemeticon.common.utils.CertificationGenerator;
 import com.jinddung2.givemeticon.domain.coupon.domain.Coupon;
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponType;
+import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyIssuedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.AlreadyRedeemedCouponException;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCoupon;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponMapper;
@@ -42,13 +43,29 @@ class CouponServiceTest {
         int couponLength = 16;
 
         String randomNum = "1234567812345678";
-        when(couponMapper.save(any(Coupon.class))).thenReturn(2);
+        when(couponMapper.saveIfNotIssued(any(Coupon.class))).thenReturn(1);
         when(certificationGenerator.createCouponNumber(couponLength)).thenReturn(randomNum);
 
         sut.createCoupon(userId, stockId, couponName, CouponType.FREE_POINT, price);
 
-        verify(couponMapper).save(any(Coupon.class));
+        verify(couponMapper).saveIfNotIssued(any(Coupon.class));
         verify(certificationGenerator).createCouponNumber(couponLength);
+    }
+
+    @Test
+    @DisplayName("동일 사용자와 재고의 쿠폰이 이미 발급된 경우 쿠폰 생성에 실패한다.")
+    void create_coupon_fail_already_issued() {
+        int stockId = 1;
+        String couponName = "테스트 선착순 쿠폰";
+        int price = 10_000;
+        int userId = 1;
+        int couponLength = 16;
+
+        when(certificationGenerator.createCouponNumber(couponLength)).thenReturn("1234567812345678");
+        when(couponMapper.saveIfNotIssued(any(Coupon.class))).thenReturn(0);
+
+        assertThrows(AlreadyIssuedCouponException.class,
+                () -> sut.createCoupon(userId, stockId, couponName, CouponType.FREE_POINT, price));
     }
 
     @Test

--- a/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponStockServiceTest.java
+++ b/src/test/java/com/jinddung2/givemeticon/domain/coupon/service/CouponStockServiceTest.java
@@ -1,6 +1,7 @@
 package com.jinddung2.givemeticon.domain.coupon.service;
 
 import com.jinddung2.givemeticon.domain.coupon.domain.CouponStock;
+import com.jinddung2.givemeticon.domain.coupon.exception.NotEnoughCouponStockException;
 import com.jinddung2.givemeticon.domain.coupon.exception.NotFoundCouponStock;
 import com.jinddung2.givemeticon.domain.coupon.mapper.CouponStockMapper;
 import org.junit.jupiter.api.Assertions;
@@ -11,7 +12,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.redisson.api.RedissonClient;
 
 import java.util.Optional;
 
@@ -24,14 +24,8 @@ class CouponStockServiceTest {
     @Mock
     CouponStockMapper couponStockMapper;
 
-    @Mock
-    RedissonClient redissonClient;
-
     int stockId = 1;
     int total = 100;
-
-    @Mock
-    CouponStock mockStock = CouponStock.of(total);
 
     @Test
     @DisplayName("쿠폰 재고 객체를 가져오는데 성공한다.")
@@ -56,13 +50,21 @@ class CouponStockServiceTest {
     }
 
     @Test
-    @DisplayName("쿠폰 재고 감소에 성공한다.")
-    void decrease_Stock() throws InterruptedException {
+    @DisplayName("쿠폰 재고 감소는 조건부 update affected row가 1이면 성공한다.")
+    void decrease_Stock() {
+        Mockito.when(couponStockMapper.decreaseStockIfEnough(stockId)).thenReturn(1);
 
-        couponStockService.decreaseStock(mockStock);
+        couponStockService.decreaseStock(stockId);
 
-        Mockito.verify(mockStock).decrease();
-        Mockito.verify(couponStockMapper).decreaseStock(mockStock.getId(), mockStock.getRemain());
+        Mockito.verify(couponStockMapper).decreaseStockIfEnough(stockId);
+    }
 
+    @Test
+    @DisplayName("쿠폰 재고 감소 affected row가 0이면 재고 부족 예외가 발생한다.")
+    void decrease_Stock_Fail_Not_Enough_Stock() {
+        Mockito.when(couponStockMapper.decreaseStockIfEnough(stockId)).thenReturn(0);
+
+        Assertions.assertThrows(NotEnoughCouponStockException.class,
+                () -> couponStockService.decreaseStock(stockId));
     }
 }


### PR DESCRIPTION
* close #131

# Why

선착순 쿠폰 발급 과정에서 중복 발급과 초과 발급 가능성을 DB 정합성 기준으로 보완하기 위해 작업했습니다.

기존에는 Redis 기반 분산락으로 동일 `coupon_stock.id` 요청을 직렬화하고 있었지만, 실무적으로 분산락은 Redis 장애, 네트워크 지연, leaseTime 만료 등의 영향을 받을 수 있습니다.

따라서 최종 정합성을 분산락에만 의존하지 않고, DB 조건부 update와 중복 발급 방지 기준을 함께 사용하여 DB가 최종 방어선 역할을 하도록 개선했습니다.

---

# What Changed

주요 변경사항

### Application

* `coupon_stock.remain > 0` 조건부 update 기반 재고 차감 유지
* affected row가 0이면 쿠폰 생성 중단
* 동일 사용자 + 동일 `stockId` 중복 발급 방지 로직 보완
* 재고 차감 성공 이후에만 쿠폰 생성 진행
* 관련 동시성 테스트 추가 및 보강
* 기존 분산락 구조 유지
* 기존 API 응답 구조 유지

### Database

* `coupon_stock` 재고 차감을 atomic conditional update 방식으로 유지

```sql
UPDATE coupon_stock
SET remain = remain - 1
WHERE id = #{stockId}
  AND remain > 0;
```

* `(user_id, stock_id)` 기준 unique constraint 적용 검토
* 기존 중복 데이터 존재 여부 확인 로직 추가

### Infrastructure

* MySQL + Redis 기반 동시성 검증 환경 사용
* `mysql-test` profile 기반 통합 테스트 추가
* 실제 MyBatis/MySQL 환경에서 정합성 검증 가능하도록 테스트 구성

---

# Key Decisions

중요한 설계 결정

### Decision

* 분산락을 제거하지 않고 DB를 최종 정합성 방어선으로 사용

### Reason

* 분산락은 성능과 직렬화에는 유효하지만, leaseTime 만료나 장애 상황에서는 완전한 정합성을 보장할 수 없음
* DB conditional update와 unique constraint는 최종 consistency 보장에 적합함

### Alternatives Considered

* Redis 단독 정합성 관리

  * Redis 장애 시 정합성 위험 존재
* 비관적 락 기반 전체 직렬화

  * 처리량 저하 가능성 존재
* 대규모 이벤트 기반 재설계

  * 현재 작업 범위를 초과함
* distributed transaction 도입

  * 현재 구조 대비 복잡도 증가

---

# Validation

어떻게 검증했는가?

### Unit Test

* affected row가 0이면 쿠폰 생성이 진행되지 않는지 검증
* 동일 사용자 중복 발급 요청 시 중복 생성이 차단되는지 검증
* 재고 부족 시 쿠폰 생성 실패 검증

### Integration Test

* `CouponIssueMysqlConcurrencyIntegrationTest` 추가
* 실제 MySQL/MyBatis/Redis 환경에서 쿠폰 발급 흐름 검증
* 현재 로컬 DB의 `(user_id, stock_id)` 중복 데이터로 unique index 생성이 차단되는 상태 확인

### Concurrency Test

* 재고 1개에 다수 동시 요청 시 쿠폰 1개만 생성되는지 검증
* 동시 요청 후 `coupon_stock.remain`이 음수가 되지 않는지 검증
* 생성된 coupon row 수가 초기 재고 수를 초과하지 않는지 검증

---

# Risks

남아있는 위험

* 기존 `coupon` 테이블에 중복 `(user_id, stock_id)` 데이터가 존재하면 unique index 생성 실패 가능
* 재고 차감 성공 후 쿠폰 생성 실패 시 트랜잭션 경계가 올바르게 묶여 있어야 함
* 분산락 leaseTime이 트랜잭션 처리 시간보다 짧으면 중복 진입 가능성은 여전히 존재하지만, DB 조건부 update와 unique constraint가 최종 방어선 역할 수행

---

# Rollback Plan

문제 발생 시 복구 방법

* 신규 unique constraint 제거
* 쿠폰 발급 로직을 이전 애플리케이션 체크 방식으로 복원
* 추가된 동시성 테스트 및 integration test 롤백
* 쿠폰 발급 관련 변경 파일만 selective revert 수행
